### PR TITLE
Changed epos to configs when referring to all electron positions.

### DIFF
--- a/energy.py
+++ b/energy.py
@@ -3,18 +3,18 @@ import scipy
 import scipy.spatial
 
 
-def ee_energy(epos):
-    ne=epos.shape[1]
-    ee=np.zeros(epos.shape[0])
+def ee_energy(configs):
+    ne=configs.shape[1]
+    ee=np.zeros(configs.shape[0])
     for i in range(ne):
         for j in range(i+1,ne):
-            ee+=1./np.sqrt(np.sum((epos[:,i,:]-epos[:,j,:])**2,axis=1))
+            ee+=1./np.sqrt(np.sum((configs[:,i,:]-configs[:,j,:])**2,axis=1))
     return ee
 
-def ei_energy(mol,epos):
+def ei_energy(mol,configs):
     ei=0.0
     for c,coord in zip(mol.atom_charges(),mol.atom_coords()):
-        delta=epos-coord[np.newaxis,np.newaxis,:]
+        delta=configs-coord[np.newaxis,np.newaxis,:]
         deltar=np.sqrt(np.sum(delta**2,axis=2))
         ei+=-c*np.sum(1./deltar,axis=1)
     return ei
@@ -28,19 +28,19 @@ def ii_energy(mol):
     ii=np.sum((np.outer(c,c)/r)[ind])
     return ii
 
-def ecp(mol,epos,wf):
+def ecp(mol,configs,wf):
     
     pass
 
-def energy(mol,epos,wf):
-    ee=ee_energy(epos)
-    ei=ei_energy(mol,epos)
+def energy(mol,configs,wf):
+    ee=ee_energy(configs)
+    ei=ei_energy(mol,configs)
     ii=ii_energy(mol)
-    nconf=epos.shape[0]
+    nconf=configs.shape[0]
     ke=np.zeros(nconf)
-    nelec=epos.shape[1]
+    nelec=configs.shape[1]
     for e in range(nelec):
-        ke+=-0.5*wf.laplacian(e,epos[:,e,:])
+        ke+=-0.5*wf.laplacian(e,configs[:,e,:])
     return {'ke':ke,
             'ee':ee,
             'ei':ei,

--- a/mc.py
+++ b/mc.py
@@ -8,7 +8,7 @@ def initial_guess(mol,nconfig,r=1.0):
     """ Generate an initial guess by distributing electrons near atoms
     proportional to their charge."""
     nelec=np.sum(mol.nelec)
-    epos=np.zeros((nconfig,nelec,3))
+    configs=np.zeros((nconfig,nelec,3))
     wts=mol.atom_charges()
     wts=wts/np.sum(wts)
 
@@ -27,9 +27,9 @@ def initial_guess(mol,nconfig,r=1.0):
                 neach[i]+=1
             for n,coord in zip(neach,mol.atom_coords()):
                 for i in range(int(n)):
-                    epos[c,count,:]=coord+r*np.random.randn(3)
+                    configs[c,count,:]=coord+r*np.random.randn(3)
                     count+=1
-    return epos
+    return configs
     
 
 

--- a/multiplywf.py
+++ b/multiplywf.py
@@ -15,14 +15,14 @@ class MultiplyWF:
         self.parameters=ChainMap(self.wf1.parameters,self.wf2.parameters)
 
         
-    def recompute(self,epos):
-        v1=self.wf1.recompute(epos)
-        v2=self.wf2.recompute(epos)
+    def recompute(self,configs):
+        v1=self.wf1.recompute(configs)
+        v2=self.wf2.recompute(configs)
         return v1[0]*v2[0],v1[1]+v2[1]
 
-    def updateinternals(self,epos,mask=None):
-        self.wf1.updateinternals(epos,mask)
-        self.wf2.updateinternals(epos,mask)
+    def updateinternals(self,configs,mask=None):
+        self.wf1.updateinternals(configs,mask)
+        self.wf2.updateinternals(configs,mask)
 
 
     def value(self):
@@ -67,13 +67,13 @@ def test():
     slater=PySCFSlaterRHF(nconf,mol,mf)
     jastrow=Jastrow2B(nconf,mol)
     jastrow.parameters['coeff']=np.random.random(jastrow.parameters['coeff'].shape)
-    epos=np.random.randn(nconf,4,3)
+    configs=np.random.randn(nconf,4,3)
     wf=MultiplyWF(nconf,slater,jastrow)
     import testwf
     for delta in [1e-3,1e-4,1e-5,1e-6,1e-7]:
-        print('delta', delta, "Testing gradient",testwf.test_wf_gradient(wf,epos,delta=delta))
-        print('delta', delta, "Testing laplacian", testwf.test_wf_laplacian(wf,epos,delta=delta))
-        print('delta', delta, "Testing pgradient", testwf.test_wf_pgradient(wf,epos,delta=delta))
+        print('delta', delta, "Testing gradient",testwf.test_wf_gradient(wf,configs,delta=delta))
+        print('delta', delta, "Testing laplacian", testwf.test_wf_laplacian(wf,configs,delta=delta))
+        print('delta', delta, "Testing pgradient", testwf.test_wf_pgradient(wf,configs,delta=delta))
     
 if __name__=="__main__":
     test()

--- a/slater.py
+++ b/slater.py
@@ -28,10 +28,10 @@ class PySCFSlaterRHF:
         self._movals=np.zeros((nconfig,2,self._nup,nmo)) # row is electron, column is mo
         self._inverse=np.zeros((nconfig,2,self._nup,self._nup))
             
-    def recompute(self,epos):
+    def recompute(self,configs):
         """This computes the value from scratch. Returns the logarithm of the wave function as
         (phase,logdet). If the wf is real, phase will be +/- 1."""
-        mycoords=epos.reshape((epos.shape[0]*epos.shape[1],epos.shape[2]))
+        mycoords=configs.reshape((configs.shape[0]*configs.shape[1],configs.shape[2]))
         ao = self._mol.eval_gto('GTOval_sph', mycoords)
         mo = ao.dot(self.parameters['mo_coeff'])
         self._movals=mo.reshape((self._nconfig,2,self._nup,self._nup))
@@ -117,24 +117,24 @@ def test():
     nconf=10
     nelec=np.sum(mol.nelec)
     slater=PySCFSlaterRHF(nconf,mol,mf)
-    epos=np.random.randn(nconf,nelec,3)
+    configs=np.random.randn(nconf,nelec,3)
     import testwf
     for delta in [1e-3,1e-4,1e-5,1e-6,1e-7]:
-        print('delta', delta, "Testing gradient",testwf.test_wf_gradient(slater,epos,delta=delta))
-        print('delta', delta, "Testing laplacian", testwf.test_wf_laplacian(slater,epos,delta=delta))
-        print('delta', delta, "Testing pgradient", testwf.test_wf_pgradient(slater,epos,delta=delta))
+        print('delta', delta, "Testing gradient",testwf.test_wf_gradient(slater,configs,delta=delta))
+        print('delta', delta, "Testing laplacian", testwf.test_wf_laplacian(slater,configs,delta=delta))
+        print('delta', delta, "Testing pgradient", testwf.test_wf_pgradient(slater,configs,delta=delta))
 
 
     quit()
     #Test the internal update
     e=3
-    slater.recompute(epos)
+    slater.recompute(configs)
     inv=slater._inverse.copy()
-    eposnew=epos.copy()
-    eposnew[:,e,:]+=0.1
-    slater.updateinternals(e,eposnew[:,e,:])
+    configsnew=configs.copy()
+    configsnew[:,e,:]+=0.1
+    slater.updateinternals(e,configsnew[:,e,:])
     inv_update=slater._inverse.copy()
-    slater.recompute(eposnew)
+    slater.recompute(configsnew)
     inv_recalc=slater._inverse.copy()
     print(inv_recalc-inv_update)
 

--- a/testwf.py
+++ b/testwf.py
@@ -1,32 +1,32 @@
 import numpy as np
 
-def test_wf_gradient(wf, epos, delta=1e-5):
+def test_wf_gradient(wf, configs, delta=1e-5):
     """ 
     Parameters:
-        wf: a wavefunction object with functions wf.recompute(epos), wf.testvalue(e,epos) and wf.gradient(e,epos)
-        epos: nconf x nelec x 3 position array to set the wf object
+        wf: a wavefunction object with functions wf.recompute(configs), wf.testvalue(e,configs) and wf.gradient(e,configs)
+        configs: nconf x nelec x 3 position array to set the wf object
         delta: the finite difference step; 1e-5 to 1e-6 seem to be the best compromise between accuracy and machine precision
-    Tests wf.gradient(e,epos) against numerical derivatives of wf.testvalue(e,epos)
+    Tests wf.gradient(e,configs) against numerical derivatives of wf.testvalue(e,configs)
     For gradient and testvalue:
         e is the electron index
-        epos is nconf x 3 positions of electron e
-    wf.testvalue(e,epos) should return a ratio: the wf value at the position where electron e is moved to epos divided by the current value
-    wf.gradient(e,epos) should return grad ln Psi(epos), while keeping all the other electrons at current position. epos may be different from the current position of electron e
+        configs is nconf x 3 positions of electron e
+    wf.testvalue(e,configs) should return a ratio: the wf value at the position where electron e is moved to configs divided by the current value
+    wf.gradient(e,configs) should return grad ln Psi(configs), while keeping all the other electrons at current position. configs may be different from the current position of electron e
     
     """
-    nconf, nelec = epos.shape[0:2]
-    wf.recompute(epos)
+    nconf, nelec = configs.shape[0:2]
+    wf.recompute(configs)
     maxerror=0
-    grad = np.zeros(epos.shape)
-    numeric = np.zeros(epos.shape)
+    grad = np.zeros(configs.shape)
+    numeric = np.zeros(configs.shape)
     for e in range(nelec):
-        grad[:,e,:] = wf.gradient(e, epos[:,e,:]).T
+        grad[:,e,:] = wf.gradient(e, configs[:,e,:]).T
         for d in range(0,3):
-            eposnew=epos.copy()
-            eposnew[:,e,d]+=delta
-            plusval=wf.testvalue(e,eposnew[:,e,:])
-            eposnew[:,e,d]-=2*delta
-            minuval=wf.testvalue(e,eposnew[:,e,:])
+            configsnew=configs.copy()
+            configsnew[:,e,d]+=delta
+            plusval=wf.testvalue(e,configsnew[:,e,:])
+            configsnew[:,e,d]-=2*delta
+            minuval=wf.testvalue(e,configsnew[:,e,:])
             numeric[:,e,d] = (plusval - minuval)/(2*delta)
     maxerror = np.amax(np.abs(grad-numeric))
     normerror = np.mean(np.abs(grad-numeric))
@@ -37,9 +37,9 @@ def test_wf_gradient(wf, epos, delta=1e-5):
 
 
 
-def test_wf_pgradient(wf,epos,delta=1e-5):
+def test_wf_pgradient(wf,configs,delta=1e-5):
     pkeys=wf.parameters.keys()
-    baseval=wf.recompute(epos)
+    baseval=wf.recompute(configs)
     gradient=wf.pgradient()
     error={}
     #This is a little tricky; you cannot assign wf.parameters[k] to a numpy array
@@ -50,12 +50,12 @@ def test_wf_pgradient(wf,epos,delta=1e-5):
         nparms=np.prod(wf.parameters[k].shape)
         indices=np.unravel_index(range(nparms),wf.parameters[k].shape)
 
-        numgrad=np.zeros((epos.shape[0],nparms))
+        numgrad=np.zeros((configs.shape[0],nparms))
         for i,ind in enumerate(indices):
             wf.parameters[k][ind]+=delta
-            plusval=wf.recompute(epos)
+            plusval=wf.recompute(configs)
             wf.parameters[k][ind]-=2*delta
-            minuval=wf.recompute(epos)
+            minuval=wf.recompute(configs)
             numgrad[:,i] = (plusval[0]*baseval[0]*np.exp(plusval[1]-baseval[1]) 
                     - minuval[0]*baseval[0]*np.exp(minuval[1]-baseval[1]))/(2*delta)
             wf.parameters[k][ind]+=delta
@@ -65,36 +65,36 @@ def test_wf_pgradient(wf,epos,delta=1e-5):
     return error
             
         
-def test_wf_laplacian(wf, epos, delta=1e-5):
+def test_wf_laplacian(wf, configs, delta=1e-5):
     """ 
     Parameters:
-        wf: a wavefunction object with functions wf.recompute(epos), wf.gradient(e,epos) and wf.laplacian(e,epos)
-        epos: nconf x nelec x 3 position array to set the wf object
+        wf: a wavefunction object with functions wf.recompute(configs), wf.gradient(e,configs) and wf.laplacian(e,configs)
+        configs: nconf x nelec x 3 position array to set the wf object
         delta: the finite difference step; 1e-5 to 1e-6 seem to be the best compromise between accuracy and machine precision
-    Tests wf.laplacian(e,epos) against numerical derivatives of wf.gradient(e,epos)
+    Tests wf.laplacian(e,configs) against numerical derivatives of wf.gradient(e,configs)
     For gradient and laplacian:
         e is the electron index
-        epos is nconf x 3 positions of electron e
-    wf.gradient(e,epos) should return grad ln Psi(epos), while keeping all the other electrons at current position. epos may be different from the current position of electron e
-    wf.laplacian(e,epos) should behave the same as gradient, except lap(\Psi(epos))/Psi(epos)
+        configs is nconf x 3 positions of electron e
+    wf.gradient(e,configs) should return grad ln Psi(configs), while keeping all the other electrons at current position. configs may be different from the current position of electron e
+    wf.laplacian(e,configs) should behave the same as gradient, except lap(\Psi(configs))/Psi(configs)
     """
-    nconf, nelec = epos.shape[0:2]
-    wf.recompute(epos)
+    nconf, nelec = configs.shape[0:2]
+    wf.recompute(configs)
     maxerror=0
-    lap = np.zeros(epos.shape[:2])
-    numeric = np.zeros(epos.shape[:2])
+    lap = np.zeros(configs.shape[:2])
+    numeric = np.zeros(configs.shape[:2])
 
     for e in range(nelec):
-        lap[:,e] = wf.laplacian(e, epos[:,e,:])
+        lap[:,e] = wf.laplacian(e, configs[:,e,:])
         
         for d in range(0,3):
-            eposnew=epos.copy()
-            eposnew[:,e,d]+=delta
-            plusval=wf.testvalue(e,eposnew[:,e,:])
-            plusgrad=wf.gradient(e,eposnew[:,e,:])[d]*plusval
-            eposnew[:,e,d]-=2*delta
-            minuval=wf.testvalue(e,eposnew[:,e,:])
-            minugrad=wf.gradient(e,eposnew[:,e,:])[d]*minuval
+            configsnew=configs.copy()
+            configsnew[:,e,d]+=delta
+            plusval=wf.testvalue(e,configsnew[:,e,:])
+            plusgrad=wf.gradient(e,configsnew[:,e,:])[d]*plusval
+            configsnew[:,e,d]-=2*delta
+            minuval=wf.testvalue(e,configsnew[:,e,:])
+            minugrad=wf.gradient(e,configsnew[:,e,:])[d]*minuval
             numeric[:,e] += (plusgrad - minugrad)/(2*delta)
     
     maxerror = np.amax(np.abs(lap-numeric))
@@ -113,8 +113,8 @@ if __name__=='__main__':
     wf=PySCFSlaterRHF(10,mol,mf)
     #wf=Jastrow2B(10,mol)
     for i in range(5):
-        epos=np.random.randn(10,4,3)
-        print("testing gradient: errors", test_wf_gradient(wf, epos, delta=1e-5))
+        configs=np.random.randn(10,4,3)
+        print("testing gradient: errors", test_wf_gradient(wf, configs, delta=1e-5))
     for i in range(5):
-        epos=np.random.randn(10,4,3)
-        print("testing laplacian: errors", test_wf_laplacian(wf, epos, delta=1e-5))
+        configs=np.random.randn(10,4,3)
+        print("testing laplacian: errors", test_wf_laplacian(wf, configs, delta=1e-5))

--- a/testwf.py
+++ b/testwf.py
@@ -9,9 +9,9 @@ def test_wf_gradient(wf, configs, delta=1e-5):
     Tests wf.gradient(e,configs) against numerical derivatives of wf.testvalue(e,configs)
     For gradient and testvalue:
         e is the electron index
-        configs is nconf x 3 positions of electron e
-    wf.testvalue(e,configs) should return a ratio: the wf value at the position where electron e is moved to configs divided by the current value
-    wf.gradient(e,configs) should return grad ln Psi(configs), while keeping all the other electrons at current position. configs may be different from the current position of electron e
+        epos is nconf x 3 positions of electron e
+    wf.testvalue(e,epos) should return a ratio: the wf value at the position where electron e is moved to epos divided by the current value
+    wf.gradient(e,epos) should return grad ln Psi(epos), while keeping all the other electrons at current position. epos may be different from the current position of electron e
     
     """
     nconf, nelec = configs.shape[0:2]
@@ -71,12 +71,12 @@ def test_wf_laplacian(wf, configs, delta=1e-5):
         wf: a wavefunction object with functions wf.recompute(configs), wf.gradient(e,configs) and wf.laplacian(e,configs)
         configs: nconf x nelec x 3 position array to set the wf object
         delta: the finite difference step; 1e-5 to 1e-6 seem to be the best compromise between accuracy and machine precision
-    Tests wf.laplacian(e,configs) against numerical derivatives of wf.gradient(e,configs)
+    Tests wf.laplacian(e,epos) against numerical derivatives of wf.gradient(e,epos)
     For gradient and laplacian:
         e is the electron index
-        configs is nconf x 3 positions of electron e
-    wf.gradient(e,configs) should return grad ln Psi(configs), while keeping all the other electrons at current position. configs may be different from the current position of electron e
-    wf.laplacian(e,configs) should behave the same as gradient, except lap(\Psi(configs))/Psi(configs)
+        epos is nconf x 3 positions of electron e
+    wf.gradient(e,epos) should return grad ln Psi(epos), while keeping all the other electrons at current position. epos may be different from the current position of electron e
+    wf.laplacian(e,epos) should behave the same as gradient, except lap(\Psi(epos))/Psi(epos)
     """
     nconf, nelec = configs.shape[0:2]
     wf.recompute(configs)


### PR DESCRIPTION
`configs` refers to the [nconfig,nelectron,ndim] array of all electrons and configurations.
`epos` is still used when it is of shape [nconfig,ndim], referring to a single electron position for each config.