### PR TITLE
Fix limdrift for cases when cutoff != 1

### DIFF
--- a/pyqmc/mc.py
+++ b/pyqmc/mc.py
@@ -78,7 +78,7 @@ def limdrift(g, cutoff=1):
     """
     tot = np.linalg.norm(g, axis=1)
     mask = tot > cutoff
-    g[mask, :] = g[mask, :] / tot[mask, np.newaxis]
+    g[mask, :] = cutoff * g[mask, :] / tot[mask, np.newaxis]
     return g
 
 


### PR DESCRIPTION
I think there is a minor error in limdrift. If the cutoff is not one the drift isn't scaled.