### PR TITLE
Jastrow cleanup

### DIFF
--- a/pyqmc/coord.py
+++ b/pyqmc/coord.py
@@ -60,7 +60,7 @@ class OpenConfigs:
         """
         self.configs[:] = np.concatenate([c.configs for c in configslist], axis=0)[:]
 
-    def copy(self): 
+    def copy(self):
         return copy.deepcopy(self)
 
 
@@ -127,7 +127,7 @@ class PeriodicConfigs:
         self.configs[:] = np.concatenate([c.configs for c in configslist], axis=0)[:]
         self.wrap[:] = np.concatenate([c.wrap for c in configslist], axis=0)[:]
 
-    def copy(self): 
+    def copy(self):
         return copy.deepcopy(self)
 
 

--- a/pyqmc/jastrowspin.py
+++ b/pyqmc/jastrowspin.py
@@ -104,26 +104,14 @@ class JastrowSpin:
 
         # Update bvalues according to spin case
         for i, b in enumerate(self.b_basis):
-            self._bvalues[:, i, 0] = np.sum(
-                b.value(d1, r1), axis=1
-            )
-            self._bvalues[:, i, 1] = np.sum(
-                b.value(d2, r2), axis=1
-            )
-            self._bvalues[:, i, 2] = np.sum(
-                b.value(d3, r3), axis=1
-            )
+            self._bvalues[:, i, 0] = np.sum( b.value(d1, r1), axis=1)
+            self._bvalues[:, i, 1] = np.sum( b.value(d2, r2), axis=1)
+            self._bvalues[:, i, 2] = np.sum( b.value(d3, r3), axis=1)
 
         # Update avalues according to spin case
         for i, a in enumerate(self.a_basis):
-            self._avalues[:, :, i, 0] = np.sum(
-                a.value(di1, ri1),
-                axis=2,
-            )
-            self._avalues[:, :, i, 1] = np.sum(
-                a.value(di2, ri2),
-                axis=2,
-            )
+            self._avalues[:, :, i, 0] = np.sum( a.value(di1, ri1), axis=2,)
+            self._avalues[:, :, i, 1] = np.sum( a.value(di2, ri2), axis=2,)
 
         u = np.sum(self._bvalues * self.parameters["bcoeff"], axis=(2, 1))
         u += np.einsum("ijkl,jkl->i", self._avalues, self.parameters["acoeff"])
@@ -333,9 +321,6 @@ class JastrowSpin:
         deltaa = self._a_update(e, epos, mask) - self._a_partial[e, mask]
         a_val = np.einsum("ijk,jk->i", deltaa, self.parameters["acoeff"][..., edown])
         deltab = self._b_update(e, epos, mask) - self._b_partial[e, mask]
-        #for i in range(len(self.b_basis)):
-            #print('b.value', self._b_partial[e, mask, i])
-        #print('deltab', deltab)
         b_val = np.einsum("ijk,jk->i",
             deltab, self.parameters["bcoeff"][:, edown:edown+2],
         )

--- a/pyqmc/jastrowspin.py
+++ b/pyqmc/jastrowspin.py
@@ -68,7 +68,7 @@ class JastrowSpin:
         self._bvalues = np.zeros((nconf, nexpand, 3))
         self._avalues = np.zeros((nconf, self._mol.natm, aexpand, 2))
         self._a_partial = np.zeros((nelec, nconf, self._mol.natm, aexpand))
-        self._b_partial = np.zeros((nelec, nconf, nexpand, 2)) 
+        self._b_partial = np.zeros((nelec, nconf, nexpand, 2))
         notmask = [True] * nconf
         for e in range(nelec):
             epos = configs.electron(e)
@@ -89,7 +89,7 @@ class JastrowSpin:
             for i, b in enumerate(self.b_basis):
                 self._bvalues[:, i, j] = np.sum(b.value(d, r), axis=1)
 
-        # electron-ion distances 
+        # electron-ion distances
         di = np.zeros((nelec, nconf, self._mol.natm, 3))
         for e in range(nelec):
             di[e] = configs.dist.dist_i(
@@ -121,7 +121,7 @@ class JastrowSpin:
         aupdate = self._a_update(e, epos, mask)
         bupdate = self._b_update(e, epos, mask)
         self._avalues[mask, :, :, edown] += aupdate - self._a_partial[e, mask]
-        self._bvalues[mask, :, edown:edown+2] += bupdate - self._b_partial[e, mask]
+        self._bvalues[mask, :, edown : edown + 2] += bupdate - self._b_partial[e, mask]
         self._a_partial[e, mask] = aupdate
         self._update_b_partial(e, epos, mask)
         self._configscurrent.move(e, epos, mask)
@@ -189,8 +189,8 @@ class JastrowSpin:
         )
         r = np.linalg.norm(d, axis=-1)
         dold = epos.dist.dist_i(
-            self._configscurrent.configs[mask][:, not_e], 
-            self._configscurrent.configs[mask, e], 
+            self._configscurrent.configs[mask][:, not_e],
+            self._configscurrent.configs[mask, e],
         )
         rold = np.linalg.norm(dold, axis=-1)
         b_partial_e = np.zeros((np.sum(mask), *self._b_partial.shape[2:]))
@@ -198,7 +198,7 @@ class JastrowSpin:
         for l, b in enumerate(self.b_basis):
             bval = b.value(d, r)
             bdiff = bval - b.value(dold, rold)
-            self._b_partial[eind, mind, l, edown] += bdiff.transpose((1,0))
+            self._b_partial[eind, mind, l, edown] += bdiff.transpose((1, 0))
             self._b_partial[e, mask, l, 0] = bval[:, :sep].sum(axis=1)
             self._b_partial[e, mask, l, 1] = bval[:, sep:].sum(axis=1)
 
@@ -231,8 +231,8 @@ class JastrowSpin:
 
         for c, b in zip(self.parameters["bcoeff"], self.b_basis):
             bgrad = b.gradient(dnew)
-            grad += c[edown] * np.sum(bgrad[:, :nup - eup], axis=1).T
-            grad += c[1 + edown] * np.sum(bgrad[:, nup - eup:], axis=1).T
+            grad += c[edown] * np.sum(bgrad[:, : nup - eup], axis=1).T
+            grad += c[1 + edown] * np.sum(bgrad[:, nup - eup :], axis=1).T
 
         for c, a in zip(self.parameters["acoeff"].transpose()[edown], self.a_basis):
             grad += np.einsum("j,ijk->ki", c, a.gradient(dinew))
@@ -245,7 +245,7 @@ class JastrowSpin:
         nup = self._mol.nelec[0]
 
         # Get e-e and e-ion distances
-        not_e = np.arange(nelec) != e 
+        not_e = np.arange(nelec) != e
         dnew = epos.dist.dist_i(self._configscurrent.configs, epos.configs)[:, not_e]
         dinew = epos.dist.dist_i(self._mol.atom_coords(), epos.configs)
 
@@ -263,10 +263,10 @@ class JastrowSpin:
         for c, b in zip(self.parameters["bcoeff"], self.b_basis):
             bgrad = b.gradient(dnew)
             blap = b.laplacian(dnew)
-            grad += c[edown] * np.sum(bgrad[:, :nup - eup], axis=1).T
-            grad += c[1 + edown] * np.sum(bgrad[:, nup - eup:], axis=1).T
-            lap += c[edown] * np.sum(blap[:, :nup - eup], axis=(1, 2))
-            lap += c[1 + edown] * np.sum(blap[:, nup - eup:], axis=(1, 2))
+            grad += c[edown] * np.sum(bgrad[:, : nup - eup], axis=1).T
+            grad += c[1 + edown] * np.sum(bgrad[:, nup - eup :], axis=1).T
+            lap += c[edown] * np.sum(blap[:, : nup - eup], axis=(1, 2))
+            lap += c[1 + edown] * np.sum(blap[:, nup - eup :], axis=(1, 2))
 
         return grad, lap + np.sum(grad ** 2, axis=0)
 
@@ -288,8 +288,8 @@ class JastrowSpin:
         deltaa = self._a_update(e, epos, mask) - self._a_partial[e, mask]
         a_val = np.einsum("ijk,jk->i", deltaa, self.parameters["acoeff"][..., edown])
         deltab = self._b_update(e, epos, mask) - self._b_partial[e, mask]
-        b_val = np.einsum("ijk,jk->i",
-            deltab, self.parameters["bcoeff"][:, edown:edown+2],
+        b_val = np.einsum(
+            "ijk,jk->i", deltab, self.parameters["bcoeff"][:, edown : edown + 2]
         )
         return np.exp(b_val + a_val)
 

--- a/pyqmc/slateruhf.py
+++ b/pyqmc/slateruhf.py
@@ -116,8 +116,8 @@ class PySCFSlaterUHF:
         self.wrap = np.zeros((configs.configs.shape))  # only needed for PBC
         mycoords = configs.configs.reshape((nconf * nelec, ndim))
         ao = self._mol.eval_gto(self.pbc_str + "GTOval_sph", mycoords).reshape(
-                (nconf, nelec, -1)
-            )
+            (nconf, nelec, -1)
+        )
 
         self._aovals = ao
         self._dets = []
@@ -172,7 +172,7 @@ class PySCFSlaterUHF:
         s = int(e >= self._nelec[0])
         if mask is None:
             return np.einsum(
-                   "ij,ij->i", vec, self._inverse[s][:, :, e - s * self._nelec[0]]
+                "ij,ij->i", vec, self._inverse[s][:, :, e - s * self._nelec[0]]
             )
 
         return np.einsum(
@@ -197,8 +197,8 @@ class PySCFSlaterUHF:
     def laplacian(self, e, epos):
         s = int(e >= self._nelec[0])
         ao = self._mol.eval_gto(self.pbc_str + "GTOval_sph_deriv2", epos.configs)[
-                [0, 4, 7, 9]
-            ]
+            [0, 4, 7, 9]
+        ]
         mo = np.dot([ao[0], ao[1:].sum(axis=0)], self.parameters[self._coefflookup[s]])
         ratios = self._testrow(e, mo[1])
         testvalue = self._testrow(e, mo[0])
@@ -207,8 +207,8 @@ class PySCFSlaterUHF:
     def gradient_laplacian(self, e, epos):
         s = int(e >= self._nelec[0])
         ao = self._mol.eval_gto(self.pbc_str + "GTOval_sph_deriv2", epos.configs)[
-                [0, 1, 2, 3, 4, 7, 9]
-            ]
+            [0, 1, 2, 3, 4, 7, 9]
+        ]
         ao = np.concatenate([ao[0:4], ao[4:].sum(axis=0, keepdims=True)])
         mo = np.dot(ao, self.parameters[self._coefflookup[s]])
         ratios = np.asarray([self._testrow(e, x) for x in mo])

--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -21,7 +21,7 @@ def test_updateinternals(wf, configs):
     wfcopy = copy.copy(wf)
     val1 = wf.recompute(configs)
     for e in range(ne):
-        #val1 = wf.recompute(configs)
+        # val1 = wf.recompute(configs)
         epos = configs.make_irreducible(e, configs.configs[:, e, :] + delta)
         ratio = wf.testvalue(e, epos)
         wf.updateinternals(e, epos)


### PR DESCRIPTION
Condensed some of the jastrow code. Still passes all the tests. Maybe reduced number of numpy calls, made the code shorter and easier to read. Ran black, caused minor changes to coord.py, slateruhf.py, testwf.py.