### PR TITLE
Polypade basis function bug fix

### DIFF
--- a/pyqmc/func3d.py
+++ b/pyqmc/func3d.py
@@ -369,15 +369,15 @@ class CutoffCuspFunction:
 
 
 def test_func3d_gradient(bf, delta=1e-5):
-    rvec = np.random.randn(150, 3)
+    rvec = np.random.randn(150,2,5,3) #Internal indices irrelevant
     grad = bf.gradient(rvec)
     numeric = np.zeros(rvec.shape)
     for d in range(3):
         pos = rvec.copy()
         pos[..., d] += delta
-        plusval = bf.value(pos, np.linalg.norm(pos, axis=1))
+        plusval = bf.value(pos, np.linalg.norm(pos, axis=-1))
         pos[..., d] -= 2 * delta
-        minuval = bf.value(pos, np.linalg.norm(pos, axis=1))
+        minuval = bf.value(pos, np.linalg.norm(pos, axis=-1))
         numeric[..., d] = (plusval - minuval) / (2 * delta)
     maxerror = np.amax(np.abs(grad - numeric))
     normerror = np.linalg.norm(grad - numeric)
@@ -385,7 +385,7 @@ def test_func3d_gradient(bf, delta=1e-5):
 
 
 def test_func3d_laplacian(bf, delta=1e-5):
-    rvec = np.random.randn(150, 3)
+    rvec = np.random.randn(150,2,5,3) #Internal indices irrelevant
     lap = bf.laplacian(rvec)
     numeric = np.zeros(rvec.shape)
     for d in range(3):

--- a/pyqmc/func3d.py
+++ b/pyqmc/func3d.py
@@ -370,7 +370,7 @@ class CutoffCuspFunction:
 
 
 def test_func3d_gradient(bf, delta=1e-5):
-    rvec = np.random.randn(150,5,10,3) #Internal indices irrelevant
+    rvec = np.random.randn(150, 5, 10, 3)  # Internal indices irrelevant
     grad = bf.gradient(rvec)
     numeric = np.zeros(rvec.shape)
     for d in range(3):
@@ -384,8 +384,9 @@ def test_func3d_gradient(bf, delta=1e-5):
     normerror = np.linalg.norm(grad - numeric)
     return (maxerror, normerror)
 
+
 def test_func3d_laplacian(bf, delta=1e-5):
-    rvec = np.random.randn(150,5,10,3) #Internal indices irrelevant
+    rvec = np.random.randn(150, 5, 10, 3)  # Internal indices irrelevant
     lap = bf.laplacian(rvec)
     numeric = np.zeros(rvec.shape)
     for d in range(3):

--- a/pyqmc/func3d.py
+++ b/pyqmc/func3d.py
@@ -185,12 +185,7 @@ class PolyPadeFunction:
         dzdx = rvec / (r * self.parameters["rcut"])
         func = dbdp * dpdz * dzdx
 
-        #func[np.outer(z > 1, [True] * 3)] = 0
-        mask = np.einsum(
-            'i...j,jk->i...k',
-            z > 1,
-            np.zeros(3,dtype=bool)[np.newaxis,:]
-        )
+        mask = np.squeeze(z > 1, axis=-1)
         func[mask] = 0
         return func
 
@@ -208,9 +203,6 @@ class PolyPadeFunction:
         dbdp = -(1 + self.parameters["beta"]) / (1 + self.parameters["beta"] * p) ** 2
         dpdz = 12 * z * (z * z - 2 * z + 1)
         dzdx = rvec / (r * self.parameters["rcut"])
-        # d2pdz2=12*(3*z*z-4*z+1)
-        # d2bdp2 = 2*self.parameters['beta']*(1+self.parameters['beta'])/(1+self.parameters['beta']*p)**3
-        # d2zdx2 = (1-(rvec/r)**2)/(r*self.parameters['rcut'])
         d2pdz2_over_dpdz = (3 * z - 1) / (z * (z - 1))
         d2bdp2_over_dbdp = (
             -2 * self.parameters["beta"] / (1 + self.parameters["beta"] * p)
@@ -227,12 +219,7 @@ class PolyPadeFunction:
             )
         )
 
-        #lapl[np.outer(z > 1, [True] * 3)] = 0
-        mask = np.einsum(
-            'i...j,jk->i...k',
-            z > 1,
-            np.zeros(3,dtype=bool)[np.newaxis,:]
-        )
+        mask = np.squeeze(z > 1, axis=-1)
         lapl[mask] = 0
         return lapl
 
@@ -383,7 +370,7 @@ class CutoffCuspFunction:
 
 
 def test_func3d_gradient(bf, delta=1e-5):
-    rvec = np.random.randn(150,2,5,3) #Internal indices irrelevant
+    rvec = np.random.randn(150,5,10,3) #Internal indices irrelevant
     grad = bf.gradient(rvec)
     numeric = np.zeros(rvec.shape)
     for d in range(3):
@@ -397,9 +384,8 @@ def test_func3d_gradient(bf, delta=1e-5):
     normerror = np.linalg.norm(grad - numeric)
     return (maxerror, normerror)
 
-
 def test_func3d_laplacian(bf, delta=1e-5):
-    rvec = np.random.randn(150,2,5,3) #Internal indices irrelevant
+    rvec = np.random.randn(150,5,10,3) #Internal indices irrelevant
     lap = bf.laplacian(rvec)
     numeric = np.zeros(rvec.shape)
     for d in range(3):

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -83,5 +83,5 @@ def test_func3d():
 
 
 if __name__ == "__main__":
-    test_wfs()
+    #test_wfs()
     test_func3d()

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -83,5 +83,5 @@ def test_func3d():
 
 
 if __name__ == "__main__":
-    #test_wfs()
+    test_wfs()
     test_func3d()


### PR DESCRIPTION
Polypade was crashing when evaluating gradient within Jastrow.gradient. This is because it was being masked improperly.

Updated func3d tests so that we can catch this kind of error in the future as well.