### PR TITLE
Reblock and more reliable tests

### DIFF
--- a/pyqmc/reblock.py
+++ b/pyqmc/reblock.py
@@ -61,6 +61,18 @@ def reblock_by2(df, ntimes, c=None):
     return newdf
 
 
+def reblock_summary(df, nblocks):
+    df = reblock(df, nblocks)
+    serr = df.sem()
+    d = {
+        "mean": df.mean(axis=0),
+        "standard error": serr,
+        "standard error error": serr / np.sqrt(2 * (len(df) - 1)),
+        "n_blocks": nblocks,
+    }
+    return pd.DataFrame(d)
+
+
 def opt_block(df):
     """
     Finds optimal block size for each variable in a dataset

--- a/pyqmc/reblock.py
+++ b/pyqmc/reblock.py
@@ -36,13 +36,23 @@ def optimally_reblocked_pyblock(data):  # , cols):
     return reblocked_data
 
 
+def _reblock(array, nblocks):
+    vals = np.array_split(array, nblocks, axis=0)
+    return [v.mean(axis=0) for v in vals]
+
+
 def reblock(df, nblocks):
     size, nbig = np.divmod(len(df), nblocks)
-    rbdf = {}
-    for col in df.columns:
-        vals = np.array_split(df[col].values, nblocks, axis=0)
-        rbdf[col] = [v.mean(axis=0) for v in vals]
-    return pd.DataFrame(rbdf)
+    if isinstance(df, pd.Series):
+        return pd.Series(_reblock(df.values, nblocks))
+    elif isinstance(df, pd.DataFrame):
+        rbdf = {col:_reblock(df[col].values, nblocks) for col in df.columns}
+        return pd.DataFrame(rbdf)
+    elif isinstance(df, np.ndarray):
+        return _reblock(df)
+    else:
+        print("WARNING: can't reblock data of type", type(df), "-- not reblocking.")
+        return df
 
 
 def reblock_by2(df, ntimes, c=None):

--- a/pyqmc/reblock.py
+++ b/pyqmc/reblock.py
@@ -36,7 +36,17 @@ def optimally_reblocked_pyblock(data):  # , cols):
     return reblocked_data
 
 
-def reblock_by2(df, n, c=None):
+def reblock(df, nblocks):
+    size, nbig = np.divmod(len(df), nblocks)
+    rbdf = {}
+    for col in df.columns:
+        vals = np.array_split(df[col].values, nblocks, axis=0)
+        rbdf[col] = [v.mean(axis=0) for v in vals]
+    return pd.DataFrame(rbdf)
+
+
+
+def reblock_by2(df, ntimes, c=None):
     """
         Reblocks data according to “Error estimates on averages of correlated data”,
         H. Flyvbjerg, H.G. Petersen, J. Chem. Phys. 91, 461 (1989).
@@ -44,19 +54,11 @@ def reblock_by2(df, n, c=None):
     newdf = df.copy()
     if c is not None:
         newdf = newdf[c]
-    for i in range(n):
+    for i in range(ntimes):
         m = newdf.shape[0]
         lasteven = m - int(m % 2 == 1)
         newdf = (newdf[:lasteven:2] + newdf[1::2].values) / 2
     return newdf
-
-
-def reblock(df, nblocks):
-    size, nbig = np.divmod(len(df), nblocks)
-    groups = np.repeat(
-        np.arange(nblocks), [size + 1] * nbig + [size] * (nblocks - nbig)
-    )
-    return df.copy().groupby(groups).mean()
 
 
 def opt_block(df):

--- a/pyqmc/reblock.py
+++ b/pyqmc/reblock.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 
+
 def optimally_reblocked(data):
     """
         Find optimal reblocking of input data. Takes in pandas
@@ -11,15 +12,18 @@ def optimally_reblocked(data):
     n_reblock = int(np.amax(opt))
     rb_data = reblock(data, n_reblock)
     serr = rb_data.sem(axis=0)
-    d = {"mean": rb_data.mean(axis=0), 
-         "standard error": serr,
-         "standard error error": serr / np.sqrt(2 * (len(rb_data) - 1)),
-         "reblocks": n_reblock,
+    d = {
+        "mean": rb_data.mean(axis=0),
+        "standard error": serr,
+        "standard error error": serr / np.sqrt(2 * (len(rb_data) - 1)),
+        "reblocks": n_reblock,
     }
     return pd.DataFrame(d)
 
+
 def optimally_reblocked_pyblock(data):  # , cols):
     import pyblock
+
     """
         Uses pyblock to find optimal reblocking of input data. Takes in pandas
         DataFrame of raw data and selected columns to reblock, returns DataFrame
@@ -31,7 +35,8 @@ def optimally_reblocked_pyblock(data):  # , cols):
     reblocked_data["reblocks"] = reblocks
     return reblocked_data
 
-def reblock(df, n, c=None): 
+
+def reblock(df, n, c=None):
     """
         Reblocks data according to “Error estimates on averages of correlated data”,
         H. Flyvbjerg, H.G. Petersen, J. Chem. Phys. 91, 461 (1989).
@@ -41,9 +46,10 @@ def reblock(df, n, c=None):
         newdf = newdf[c]
     for i in range(n):
         m = newdf.shape[0]
-        lasteven = m - int(m%2==1)
-        newdf = (newdf[:lasteven:2]+newdf[1::2].values)/2
+        lasteven = m - int(m % 2 == 1)
+        newdf = (newdf[:lasteven:2] + newdf[1::2].values) / 2
     return newdf
+
 
 def opt_block(df):
     """
@@ -55,24 +61,25 @@ def opt_block(df):
     newdf = df.copy()
     iblock = 0
     ndata, nvariables = tuple(df.shape[:2])
-    optimal_block = np.array([float('NaN')]*nvariables)
+    optimal_block = np.array([float("NaN")] * nvariables)
     serr0 = df.sem(axis=0).values
     statslist = []
-    while(newdf.shape[0]>1):
+    while newdf.shape[0] > 1:
         serr = newdf.sem(axis=0).values
-        serrerr = serr/(2*(newdf.shape[0]-1))**.5
+        serrerr = serr / (2 * (newdf.shape[0] - 1)) ** 0.5
         statslist.append((iblock, serr.copy()))
 
         n = newdf.shape[0]
-        lasteven = n - int(n%2==1)
-        newdf = (newdf[:lasteven:2]+newdf[1::2].values)/2
+        lasteven = n - int(n % 2 == 1)
+        newdf = (newdf[:lasteven:2] + newdf[1::2].values) / 2
         iblock += 1
     for iblock, serr in reversed(statslist):
-        B3 = 2**(3*iblock)
-        inds = np.where(B3 >= 2*ndata*(serr/serr0)**4)[0]
+        B3 = 2 ** (3 * iblock)
+        inds = np.where(B3 >= 2 * ndata * (serr / serr0) ** 4)[0]
         optimal_block[inds] = iblock
 
     return optimal_block
+
 
 def test_reblocking():
     """

--- a/pyqmc/reblock.py
+++ b/pyqmc/reblock.py
@@ -45,7 +45,6 @@ def reblock(df, nblocks):
     return pd.DataFrame(rbdf)
 
 
-
 def reblock_by2(df, ntimes, c=None):
     """
         Reblocks data according to “Error estimates on averages of correlated data”,

--- a/pyqmc/reblock.py
+++ b/pyqmc/reblock.py
@@ -8,8 +8,15 @@ def optimally_reblocked(data):
         of reblocked data.
     """
     opt = opt_block(data)
-    reblocked_data = reblock(data, np.amax(opt))
-    return reblocked_data
+    n_reblock = int(np.amax(opt))
+    rb_data = reblock(data, n_reblock)
+    serr = rb_data.sem(axis=0)
+    d = {"mean": rb_data.mean(axis=0), 
+         "standard error": serr,
+         "standard error error": serr / np.sqrt(2 * (len(rb_data) - 1)),
+         "reblocks": n_reblock,
+    }
+    return pd.DataFrame(d)
 
 def optimally_reblocked_pyblock(data):  # , cols):
     import pyblock
@@ -24,8 +31,11 @@ def optimally_reblocked_pyblock(data):  # , cols):
     reblocked_data["reblocks"] = reblocks
     return reblocked_data
 
-def reblock(df, n, c): 
-    start = time.time()
+def reblock(df, n, c=None): 
+    """
+        Reblocks data according to “Error estimates on averages of correlated data”,
+        H. Flyvbjerg, H.G. Petersen, J. Chem. Phys. 91, 461 (1989).
+    """
     newdf = df.copy()
     if c is not None:
         newdf = newdf[c]
@@ -42,14 +52,11 @@ def opt_block(df):
     reblock each column over samples to find the best block size
     Returns optimal_block, a 1D array with the optimal size for each column in df
     """
-    start = time.time()
     newdf = df.copy()
     iblock = 0
     ndata, nvariables = tuple(df.shape[:2])
     optimal_block = np.array([float('NaN')]*nvariables)
     serr0 = df.sem(axis=0).values
-    print('serr0.shape',serr0.shape, time.time()-start)
-    print('ndata',ndata, time.time()-start)
     statslist = []
     while(newdf.shape[0]>1):
         serr = newdf.sem(axis=0).values
@@ -57,7 +64,6 @@ def opt_block(df):
         statslist.append((iblock, serr.copy()))
 
         n = newdf.shape[0]
-        print(iblock, n, time.time()-start)
         lasteven = n - int(n%2==1)
         newdf = (newdf[:lasteven:2]+newdf[1::2].values)/2
         iblock += 1
@@ -65,9 +71,8 @@ def opt_block(df):
         B3 = 2**(3*iblock)
         inds = np.where(B3 >= 2*ndata*(serr/serr0)**4)[0]
         optimal_block[inds] = iblock
-        print(iblock, len(inds), time.time()-start)
 
-  return optimal_block
+    return optimal_block
 
 def test_reblocking():
     """
@@ -81,20 +86,6 @@ def test_reblocking():
             https://pyblock.readthedocs.io/en/latest/tutorial.html.
         """
         return np.convolve(np.random.randn(2 ** N), np.ones(2 ** L) / 10, "same")
-
-    def reblock(data, reblocks, col):
-        """
-            Reblocks data according to “Error estimates on averages of correlated data”,
-            H. Flyvbjerg, H.G. Petersen, J. Chem. Phys. 91, 461 (1989).
-        """
-        edat = data[col].values
-        n = len(edat)
-        for i in range(reblocks):
-            edat_prime = []
-            for j in range(1, int(len(edat) / 2 + 1)):
-                edat_prime.append((edat[2 * j - 2] + edat[2 * j - 1]) / 2)
-            edat = edat_prime
-        return np.array(edat)
 
     n = 11
     cols = ["test_data1", "test_data2"]

--- a/tests/test_dmc.py
+++ b/tests/test_dmc.py
@@ -9,8 +9,7 @@ import sys
 import numpy as np
 import pyqmc.testwf as testwf
 import pytest
-import pyblock.pd_utils as pyblock
-
+from pyqmc import reblock
 
 def test():
     """ Ensure that DMC obtains the exact result for a hydrogen atom """
@@ -63,12 +62,9 @@ def test():
     warmup = 200
     dfprod = dfdmc[dfdmc.step > warmup]
 
-    reblock = pyblock.reblock(dfprod[["energytotal", "energyei"]])
-    print(reblock[1])
-    dfoptimal = reblock[1][reblock[1][("energytotal", "optimal block")] != ""]
-    energy = dfoptimal[("energytotal", "mean")].values[0]
-    err = dfoptimal[("energytotal", "standard error")].values[0]
-    print("energy", energy, "+/-", err)
+    rb_summary = reblock.optimally_reblocked(dfprod[["energytotal", "energyei"]])
+    print(rb_summary)
+    energy, err = [rb_summary[v]["energytotal"] for v in ("mean", "standard error")]
     assert (
         np.abs(energy + 0.5) < 5 * err
     ), "energy not within {0} of -0.5: energy {1}".format(5 * err, np.mean(energy))

--- a/tests/test_multislater.py
+++ b/tests/test_multislater.py
@@ -81,7 +81,7 @@ def test():
         )
 
         df = pd.DataFrame(df)
-        df = reblock(df["energytotal"][warmup:], 2)
+        df = reblock(df["energytotal"][warmup:], 20)
         en = df.mean()
         err = df.sem()
         assert en - mc.e_tot < 5 * err

--- a/tests/test_multislater.py
+++ b/tests/test_multislater.py
@@ -84,7 +84,7 @@ def test():
         df = reblock(df["energytotal"][warmup:], 2)
         en = df.mean()
         err = df.sem()
-        assert en - mc.e_tot < 4 * err
+        assert en - mc.e_tot < 5 * err
 
 if __name__ == "__main__":
     test()

--- a/tests/test_multislater.py
+++ b/tests/test_multislater.py
@@ -12,6 +12,7 @@ from pyqmc.mc import vmc, initial_guess
 from pyqmc.accumulators import EnergyAccumulator
 from pyqmc.multislater import MultiSlater
 from pyqmc.coord import OpenConfigs
+from pyqmc.reblock import reblock
 import pyqmc
 
 def test():
@@ -30,7 +31,7 @@ def test():
         epsilon = 1e-5
         nconf = 10
         nelec = np.sum(mol.nelec)
-        epos = OpenConfigs(np.random.randn(nconf, nelec, 3))
+        epos = initial_guess(mol, nconf)
       
         for k, item in testwf.test_updateinternals(wf, epos).items():
             assert item < epsilon
@@ -46,7 +47,7 @@ def test():
         epsilon = 1e-5
         nconf = 10
         nelec = np.sum(mol.nelec)
-        epos = OpenConfigs(np.random.randn(nconf, nelec, 3))
+        epos = initial_guess(mol, nconf)
       
         for k, item in testwf.test_updateinternals(wf, epos).items():
             assert item < epsilon
@@ -62,7 +63,7 @@ def test():
         epsilon = 1e-5
         nconf = 10
         nelec = np.sum(mol.nelec)
-        epos = OpenConfigs(np.random.randn(nconf, nelec, 3))
+        epos = initial_guess(mol, nconf)
       
         for k, item in testwf.test_updateinternals(wf, epos).items():
             assert item < epsilon
@@ -80,9 +81,10 @@ def test():
         )
 
         df = pd.DataFrame(df)
-        en = np.mean(df["energytotal"][warmup:])
-        err = np.std(df["energytotal"][warmup:]) / np.sqrt(nsteps - warmup)
-        assert en - mc.e_tot < 10 * err
+        df = reblock(df["energytotal"][warmup:], 2)
+        en = df.mean()
+        err = df.sem()
+        assert en - mc.e_tot < 4 * err
 
 if __name__ == "__main__":
     test()

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -81,9 +81,9 @@ def runtest(mol, mf, kind):
     df = pd.DataFrame(df)
     dfke = reblock(df["energyke"][warmup:], 2)
     vmcke, err = dfke.mean(), dfke.sem()
-    print('VMC kinetic energy: {0} $\pm$ {1}'.format(vmcke, err))
+    print('VMC kinetic energy: {0} +- {1}'.format(vmcke, err))
     
-    assert np.abs(vmcke-pyscfke) < 4 * err, \
+    assert np.abs(vmcke-pyscfke) < 5 * err, \
         "energy diff not within 5 sigma ({0:.6f}): energies \n{1} \n{2}".format(5 * err, vmcke, pyscfke)
 
 

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -79,7 +79,7 @@ def runtest(mol, mf, kind):
     )
     print("VMC time", time.time()-start)
     df = pd.DataFrame(df)
-    dfke = reblock(df["energyke"][warmup:], 2)
+    dfke = reblock(df["energyke"][warmup:], 8)
     vmcke, err = dfke.mean(), dfke.sem()
     print('VMC kinetic energy: {0} +- {1}'.format(vmcke, err))
     

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -1,10 +1,8 @@
 import numpy as np
-from pyqmc.distance import MinimalImageDistance, RawDistance
-from pyqmc.pbc import enforce_pbc
 import pyqmc
 import pandas as pd
 from pyscf.pbc import gto, scf
-from pyqmc.reblock import optimally_reblocked
+from pyqmc.reblock import reblock
 import time
 
 def test_cubic(kind=0, nk=(1,1,1)): 
@@ -77,15 +75,15 @@ def runtest(mol, mf, kind):
     warmup = 10
     start = time.time()
     df, coords = pyqmc.vmc(
-        wf, coords, nsteps=30+warmup, tstep=1, accumulators={"energy": pyqmc.accumulators.EnergyAccumulator(mol)}, verbose=False,
+        wf, coords, nsteps=32+warmup, tstep=1, accumulators={"energy": pyqmc.accumulators.EnergyAccumulator(mol)}, verbose=False,
     )
     print("VMC time", time.time()-start)
     df = pd.DataFrame(df)
-    dfke = df["energyke"][warmup:]
-    vmcke, err = dfke.mean(), dfke.std()/np.sqrt(len(dfke))
+    dfke = reblock(df["energyke"][warmup:], 2)
+    vmcke, err = dfke.mean(), dfke.sem()
     print('VMC kinetic energy: {0} $\pm$ {1}'.format(vmcke, err))
     
-    assert np.abs(vmcke-pyscfke) < 5 * err, \
+    assert np.abs(vmcke-pyscfke) < 4 * err, \
         "energy diff not within 5 sigma ({0:.6f}): energies \n{1} \n{2}".format(5 * err, vmcke, pyscfke)
 
 

--- a/tests/test_vmc.py
+++ b/tests/test_vmc.py
@@ -41,7 +41,7 @@ def test_vmc():
         en = df.mean()
         err = df.sem()
         assert (
-            en - mf.energy_tot() < 4 * err
+            en - mf.energy_tot() < 5 * err
         ), "pyscf {0}, vmc {1}, err {2}".format(en, mf.enery_tot(), err)
 
 

--- a/tests/test_vmc.py
+++ b/tests/test_vmc.py
@@ -37,7 +37,7 @@ def test_vmc():
         )
 
         df = pd.DataFrame(df)
-        df = reblock(df["energytotal"][warmup:], 2)
+        df = reblock(df["energytotal"][warmup:], 20)
         en = df.mean()
         err = df.sem()
         assert (

--- a/tests/test_vmc.py
+++ b/tests/test_vmc.py
@@ -40,9 +40,9 @@ def test_vmc():
         df = reblock(df["energytotal"][warmup:], 20)
         en = df.mean()
         err = df.sem()
-        assert (
-            en - mf.energy_tot() < 5 * err
-        ), "pyscf {0}, vmc {1}, err {2}".format(en, mf.enery_tot(), err)
+        assert en - mf.energy_tot() < 5 * err, "pyscf {0}, vmc {1}, err {2}".format(
+            en, mf.enery_tot(), err
+        )
 
 
 def test_accumulator():

--- a/tests/test_vmc.py
+++ b/tests/test_vmc.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from pyqmc.mc import vmc, initial_guess
 from pyscf import lib, gto, scf
-
+from pyqmc.reblock import reblock
 from pyqmc.slateruhf import PySCFSlaterUHF
 from pyqmc.accumulators import EnergyAccumulator
 
@@ -37,10 +37,11 @@ def test_vmc():
         )
 
         df = pd.DataFrame(df)
-        en = np.mean(df["energytotal"][warmup:])
-        err = np.std(df["energytotal"][warmup:]) / np.sqrt(nsteps - warmup)
+        df = reblock(df["energytotal"][warmup:], 2)
+        en = df.mean()
+        err = df.sem()
         assert (
-            en - mf.energy_tot() < 10 * err
+            en - mf.energy_tot() < 4 * err
         ), "pyscf {0}, vmc {1}, err {2}".format(en, mf.enery_tot(), err)
 
 


### PR DESCRIPTION
Addressing issue #94 

Implemented reblocking in our own code and checked against pyblock. (The reblock test still passes as well.) optimally_reblock() has the same interface as before; added function reblock(df, n) to reblock n times.

In all tests that run VMC and DMC, I reblocked the data twice before computing errors. Not rigorous, but I think the error estimates will be better now. Can change again if we want to improve.

Also changed test configurations in test_multislater.py to initial_guess instead of np.random.random