### PR TITLE
Jastrow speed improvements and code organization

### DIFF
--- a/pyqmc/func3d.py
+++ b/pyqmc/func3d.py
@@ -76,14 +76,14 @@ class GaussianFunction:
         lap = (4 * alpha * alpha * x * x - 2 * alpha) * v
         return grad, lap
 
-    def pgradient(self, x):
+    def pgradient(self, x, r):
         """Returns parameters gradient.
         Parameters:
           x: (nconfig,...,3) vector
         Returns:
           pgrad: dictionary {'exponent':d/dexponent}
         """
-        r2 = np.sum(x ** 2, axis=-1)
+        r2 = r * r
         return {"exponent": -r2 * np.exp(-self.parameters["exponent"] * r2)}
 
 
@@ -104,7 +104,6 @@ class PadeFunction:
         Return:
           func: same dimensions as rvec, but the last one removed 
         """
-        # r = np.linalg.norm(rvec, axis=-1)
         a = self.parameters["alphak"] * r
         return (a / (1 + a)) ** 2
 
@@ -152,14 +151,13 @@ class PadeFunction:
         lap = temp * (1 - 3 * a / (1 + a) * (rvec / r[..., np.newaxis]) ** 2)
         return grad, lap
 
-    def pgradient(self, rvec):
+    def pgradient(self, rvec, r):
         """ Return gradient of value with respect to parameter alphak
         Parameters:
           rvec: nconf x ... x 3
         Return:
           pgrad: dictionary {'alphak':d/dalphak} with akderiv dimensions (config,)
         """
-        r = np.linalg.norm(rvec, axis=-1)
         a = self.parameters["alphak"] * r
         akderiv = 2 * a / (1 + a) ** 3 * r
         return {"alphak": akderiv}
@@ -202,17 +200,16 @@ class PolyPadeFunction:
         Returns:
           grad: (nconf,...,3)
         """
-        z = r[..., np.newaxis] / self.parameters["rcut"]
-        mask = (z > 1) * np.ones(rvec.shape).astype(bool)
+        grad = np.zeros(rvec.shape)
+        mask = r <= self.parameters["rcut"]
+        r = r[mask, np.newaxis]
+        z = r / self.parameters["rcut"]
         p = z * z * (6 - 8 * z + 3 * z * z)
         dpdz = 12 * z * (z * z - 2 * z + 1)
         dbdp = -(1 + self.parameters["beta"]) / (1 + self.parameters["beta"] * p) ** 2
-        dzdx = rvec / (r[..., np.newaxis] * self.parameters["rcut"])
-        func = dbdp * dpdz * dzdx
-
-        mask = np.squeeze(z > 1, axis=-1)
-        func[mask] = 0
-        return func
+        dzdx = rvec[mask] / (r * self.parameters["rcut"])
+        grad[mask] = dbdp * dpdz * dzdx
+        return grad
 
     def laplacian(self, rvec, r):
         """
@@ -222,30 +219,24 @@ class PolyPadeFunction:
           lapl: (nconf,...,3) 
               returns components of laplacian d^2/dx_i^2 separately
         """
-        z = r[..., np.newaxis] / self.parameters["rcut"]
-        mask = (z > 1) * np.ones(rvec.shape).astype(bool)
-        p = z * z * (6 - 8 * z + 3 * z * z)
-        dbdp = -(1 + self.parameters["beta"]) / (1 + self.parameters["beta"] * p) ** 2
-        dpdz = 12 * z * (z * z - 2 * z + 1)
-        dzdx = rvec / (r[..., np.newaxis] * self.parameters["rcut"])
-        d2pdz2_over_dpdz = (3 * z - 1) / (z * (z - 1))
-        d2bdp2_over_dbdp = (
-            -2 * self.parameters["beta"] / (1 + self.parameters["beta"] * p)
-        )
-        d2zdx2_over_dzdx = (1 - (rvec / r[..., np.newaxis]) ** 2) / rvec
-        lapl = (
-            dbdp
-            * dpdz
-            * dzdx
-            * (
-                d2bdp2_over_dbdp * dpdz * dzdx
-                + d2pdz2_over_dpdz * dzdx
-                + d2zdx2_over_dzdx
-            )
-        )
+        lapl = np.zeros(rvec.shape)
+        mask = r <= self.parameters["rcut"]
+        r = r[mask, np.newaxis]
+        rvec = rvec[mask]
+        z = r / self.parameters["rcut"]
+        beta = self.parameters["beta"]
 
-        mask = np.squeeze(z > 1, axis=-1)
-        lapl[mask] = 0
+        p = z * z * (6 - 8 * z + 3 * z * z)
+        dbdp = -(1 + beta) / (1 + beta * p) ** 2
+        dpdz = 12 * z * (z * z - 2 * z + 1)
+        dzdx = rvec / (r * self.parameters["rcut"])
+        d2pdz2_over_dpdz = (3 * z - 1) / (z * (z - 1))
+        d2bdp2_over_dbdp = -2 * beta / (1 + beta * p)
+        d2zdx2_over_dzdx = (1 - (rvec / r) ** 2) / rvec
+        grad = dbdp * dpdz * dzdx
+        lapl[mask] = grad * (
+            d2bdp2_over_dbdp * dpdz * dzdx + d2pdz2_over_dpdz * dzdx + d2zdx2_over_dzdx
+        )
         return lapl
 
     def gradient_laplacian(self, rvec, r):
@@ -257,12 +248,12 @@ class PolyPadeFunction:
           grad, lap: (nconfig,...,3) vectors (components of laplacian d^2/dx_i^2 separately)
         """
         grad = np.zeros(rvec.shape)
-        z = r / self.parameters["rcut"]
-        mask = z <= 1
+        mask = r <= self.parameters["rcut"]
         r = r[mask, np.newaxis]
-        z = z[mask, np.newaxis]
         rvec = rvec[mask]
+        z = r / self.parameters["rcut"]
         beta = self.parameters["beta"]
+
         p = z * z * (6 - 8 * z + 3 * z * z)
         dpdz = 12 * z * (z * z - 2 * z + 1)
         dbdp = -(1 + beta) / (1 + beta * p) ** 2
@@ -278,23 +269,25 @@ class PolyPadeFunction:
 
         return grad, lap
 
-    def pgradient(self, rvec):
+    def pgradient(self, rvec, r):
         """ Returns gradient of self.value with respect to all parameters
         Parameters:
           rvec: (nconf,...,3) 
+          rvec: (nconf,...) 
         Returns:
           paramderivs: dictionary {'rcut':d/drcut,'beta':d/dbeta}
         """
-        r = np.linalg.norm(rvec, axis=-1)
-        zz = r / self.parameters["rcut"]
-        mask = zz < 1
-        z = zz[mask]
+        pderiv = {"rcut": np.zeros(r.shape), "beta": np.zeros(r.shape)}
+        mask = r <= self.parameters["rcut"]
+        r = r[mask]
+        z = r / self.parameters["rcut"]
+        beta = self.parameters["beta"]
+
         p = z * z * (6 - 8 * z + 3 * z * z)
-        dbdp = -(1 + self.parameters["beta"]) / (1 + self.parameters["beta"] * p) ** 2
+        dbdp = -(1 + beta) / (1 + beta * p) ** 2
         dpdz = 12 * z * (z * z - 2 * z + 1)
-        pderiv = {"rcut": np.zeros(r.shape), "gamma": np.zeros(r.shape)}
         pderiv["rcut"][mask] = dbdp * dpdz * (-z / self.parameters["rcut"])
-        pderiv["beta"][mask] = -p * (1 - p) / (1 + self.parameters["beta"] * p) ** 2
+        pderiv["beta"][mask] = -p * (1 - p) / (1 + beta * p) ** 2
         return pderiv
 
 
@@ -320,13 +313,9 @@ class CutoffCuspFunction:
           func: p(r/rcut)/(1+gamma*p(r/rcut))
         """
         y = r / self.parameters["rcut"]
-        # mask=y<=1
-        # func=np.zeros(r.shape)
+        gamma = self.parameters["gamma"]
         p = y - y * y + y * y * y / 3
-        # func=( - (y-y**2+y**3/3) / ( 1 + self.parameters['gamma'] * (y-y**2+y**3/3) ) + 1/(3+self.parameters['gamma']) )
-        func = -p / (1 + self.parameters["gamma"] * p) + 1 / (
-            3 + self.parameters["gamma"]
-        )
+        func = -p / (1 + gamma * p) + 1 / (3 + gamma)
         func[y > 1] = 0.0
         return func * self.parameters["rcut"]
 
@@ -337,18 +326,19 @@ class CutoffCuspFunction:
         Returns:
           grad: has same dimensions as rvec 
         """
-        y = r[..., np.newaxis] / self.parameters["rcut"]
-        mask = (y <= 1) * np.ones(rvec.shape).astype(bool)
-        func = np.zeros(rvec.shape)
-        func[mask] = (
-            -rvec
-            * (
-                (1 - 2 * y + y ** 2)
-                / (1 + self.parameters["gamma"] * (y - y ** 2 + y * y * y / 3)) ** 2
-                / (self.parameters["rcut"] * r[..., np.newaxis])
-            )
-        )[mask]
-        return func * self.parameters["rcut"]
+        grad = np.zeros(rvec.shape)
+        rcut = self.parameters["rcut"]
+        gamma = self.parameters["gamma"]
+        mask = r <= rcut
+        r = r[mask, np.newaxis]
+        y = r / rcut
+
+        a = 1 - 2 * y + y * y
+        b = y - y * y + y * y * y / 3
+        c = a / (1 + gamma * b) ** 2 / (rcut * r)
+
+        grad[mask] = -rvec[mask] * c * rcut
+        return grad
 
     def laplacian(self, rvec, r):
         """
@@ -357,41 +347,23 @@ class CutoffCuspFunction:
         Returns:
           lapl: has same dimensions as rvec, because returns components of laplacian d^2/dx_i^2 separately
         """
-        y = r / self.parameters["rcut"]
-        # dydr = 1/self.parameters['rcut']
-        mask = y <= 1
-        r = r[..., np.newaxis]
-        y = y[..., np.newaxis]
-        func = np.zeros(rvec.shape)
-        func[mask] = -(
-            (
-                (1 - 2 * y + y ** 2)
-                / r
-                / (1 + self.parameters["gamma"] * (y - y ** 2 + y ** 3 / 3)) ** 2
-                / self.parameters["rcut"]
-            )
-            + (
-                (
-                    (
-                        -2 / self.parameters["rcut"]
-                        + 2 * r / self.parameters["rcut"] ** 2
-                    )
-                    / r ** 2
-                    - (1 - 2 * y + y ** 2) / r ** 3
-                )
-                / self.parameters["rcut"]
-                / (1 + self.parameters["gamma"] * (y - y ** 2 + y ** 3 / 3)) ** 2
-                + ((1 - 2 * y + y ** 2) / self.parameters["rcut"]) ** 2
-                * (
-                    -2
-                    * self.parameters["gamma"]
-                    / (1 + self.parameters["gamma"] * (y - y ** 2 + y ** 3 / 3)) ** 3
-                )
-                / r ** 2
-            )
-            * (rvec ** 2)
-        )[mask]
-        return func * self.parameters["rcut"]
+        lap = np.zeros(rvec.shape)
+        rcut = self.parameters["rcut"]
+        gamma = self.parameters["gamma"]
+        mask = r <= rcut
+        r = r[mask, np.newaxis]
+        rvec = rvec[mask]
+        y = r / rcut
+
+        a = 1 - 2 * y + y * y
+        b = y - y * y + y * y * y / 3
+        c = a / (1 + gamma * b) ** 2 / (rcut * r)
+
+        temp = 2 * (y - 1) / (a * rcut * r)
+        temp -= 1 / r ** 2
+        temp -= 2 * c * gamma * (1 + gamma * b)
+        lap[mask] = -rcut * c * (1 + rvec ** 2 * temp)
+        return lap
 
     def gradient_laplacian(self, rvec, r):
         """Returns gradient and laplacian of function.
@@ -401,61 +373,48 @@ class CutoffCuspFunction:
         Returns:
           grad, lap: (nconfig,...,3) vectors (components of laplacian d^2/dx_i^2 separately)
         """
+        grad = np.zeros(rvec.shape)
+        lap = np.zeros(rvec.shape)
         rcut = self.parameters["rcut"]
-        y = r / rcut
-        mask = y <= 1
-        r = r[mask, np.newaxis]
-        y = y[mask, np.newaxis]
         gamma = self.parameters["gamma"]
+        mask = r <= rcut
+        r = r[mask, np.newaxis]
+        rvec = rvec[mask]
+        y = r / rcut
+
         a = 1 - 2 * y + y * y
         b = y - y * y + y * y * y / 3
         c = a / (1 + gamma * b) ** 2 / (rcut * r)
-        grad = np.zeros(rvec.shape)
-        lap = np.zeros(rvec.shape)
-        grad[mask] = -rcut * c * rvec[mask]
-        lap[mask] = (
-            -rcut
-            * c
-            * (
-                1
-                + rvec[mask] ** 2
-                * (
-                    +2 * (y - 1) / a / (rcut * r)
-                    - 1 / r ** 2
-                    - 2 * c * gamma * (1 + gamma * b)
-                )
-            )
-        )
+
+        grad[mask] = -rcut * c * rvec
+        temp = 2 * (y - 1) / (a * rcut * r)
+        temp -= 1 / r ** 2
+        temp -= 2 * c * gamma * (1 + gamma * b)
+        lap[mask] = -rcut * c * (1 + rvec ** 2 * temp)
         return grad, lap
 
-    def pgradient(self, rvec):
-        """ Returns gradient of self.value with respect all parameters
+    def pgradient(self, rvec, r):
+        """ Returns gradient of self.value with respect to all parameters
         Parameters:
           rvec: (nconf,...,3) vector
         Returns:
           paramderivs: dictionary {'rcut':d/drcut,'gamma':d/dgamma}
         """
-        r = np.linalg.norm(rvec, axis=-1)
-        y = r / self.parameters["rcut"]
-        mask = y <= 1
         func = {"rcut": np.zeros(r.shape), "gamma": np.zeros(r.shape)}
-        func["rcut"][mask] = (
-            -(
-                -r
-                / self.parameters["rcut"] ** 2
-                * (1 - 2 * y + y ** 2)
-                / (1 + self.parameters["gamma"] * (y - y ** 2 + y ** 3 / 3)) ** 2
-            )[mask]
-            * self.parameters["rcut"]
-        )
-        func["gamma"][mask] = (
-            -(
-                -(y - y ** 2 + y ** 3 / 3) ** 2
-                / (1 + self.parameters["gamma"] * (y - y ** 2 + y ** 3 / 3)) ** 2
-                - 1 / (3 + self.parameters["gamma"]) ** 2
-            )[mask]
-            * self.parameters["rcut"]
-        )
+        rcut = self.parameters["rcut"]
+        gamma = self.parameters["gamma"]
+        mask = r <= rcut
+        r = r[mask]
+        y = r / rcut
+
+        a = 1 - 2 * y + y * y
+        b = y - y * y + y * y * y / 3
+        c = a / (1 + gamma * b) ** 2 / (rcut * r)
+        val = -b / (1 + gamma * b) + 1 / (3 + gamma)
+
+        func["rcut"][mask] = y * a / (1 + gamma * b) ** 2 + val
+        func["gamma"][mask] = ((b / (1 + gamma * b)) ** 2 - 1 / (3 + gamma) ** 2) * rcut
+
         return func
 
 
@@ -471,9 +430,9 @@ def test_func3d_gradient(bf, delta=1e-5):
         pos[..., d] -= 2 * delta
         minuval = bf.value(pos, np.linalg.norm(pos, axis=-1))
         numeric[..., d] = (plusval - minuval) / (2 * delta)
-    maxerror = np.amax(np.abs(grad - numeric))
+    meanerror = np.mean(np.abs(grad - numeric))
     normerror = np.linalg.norm(grad - numeric)
-    return (maxerror, normerror)
+    return (meanerror, normerror)
 
 
 def test_func3d_laplacian(bf, delta=1e-5):
@@ -490,9 +449,9 @@ def test_func3d_laplacian(bf, delta=1e-5):
         r = np.linalg.norm(pos, axis=-1)
         minuval = bf.gradient(pos, r)[..., d]
         numeric[..., d] = (plusval - minuval) / (2 * delta)
-    maxerror = np.amax(np.abs(lap - numeric))
+    meanerror = np.mean(np.abs(lap - numeric))
     normerror = np.linalg.norm(lap - numeric)
-    return (maxerror, normerror)
+    return (meanerror, normerror)
 
 
 def test_func3d_gradient_laplacian(bf):
@@ -504,3 +463,24 @@ def test_func3d_gradient_laplacian(bf):
     graderr = np.linalg.norm((grad - andgrad))
     laperr = np.linalg.norm((lap - andlap))
     return (graderr, laperr)
+
+
+def test_func3d_pgradient(bf, delta=1e-5):
+    rvec = np.random.randn(150, 10, 3)
+    r = np.linalg.norm(rvec, axis=-1)
+    pgrad = bf.pgradient(rvec, r)
+    numeric = {k: np.zeros(v.shape) for k, v in pgrad.items()}
+    meanerror = {k: np.zeros(v.shape) for k, v in pgrad.items()}
+    normerror = {k: np.zeros(v.shape) for k, v in pgrad.items()}
+    for k in pgrad.keys():
+        bf.parameters[k] += delta
+        plusval = bf.value(rvec, r)
+        bf.parameters[k] -= 2 * delta
+        minuval = bf.value(rvec, r)
+        bf.parameters[k] += delta
+        numeric[k] = (plusval - minuval) / (2 * delta)
+        meanerror[k] = np.mean(np.abs(pgrad[k] - numeric[k]))
+        normerror[k] = np.linalg.norm(pgrad[k] - numeric[k])
+        if meanerror[k] > 1e-5:
+            print(k, "\n", pgrad[k] - numeric[k])
+    return (meanerror, normerror)

--- a/pyqmc/jastrowspin.py
+++ b/pyqmc/jastrowspin.py
@@ -153,10 +153,9 @@ class JastrowSpin:
               epos: configs object for electron e
               mask: mask over configs axis, only return values for configs where mask==True. b_partial_e might have a smaller configs axis than epos, _configscurrent, and _b_partial because of the mask.
         """
-        nelec = np.sum(self._mol.nelec)
         nup = self._mol.nelec[0]
         sep = nup - int(e < nup)
-        not_e = np.arange(nelec) != e
+        not_e = np.arange(self._nelec) != e
         d = epos.dist.dist_i(
             self._configscurrent.configs[mask][:, not_e], epos.configs[mask]
         )
@@ -179,10 +178,9 @@ class JastrowSpin:
               epos: configs object for electron e
               mask: mask over configs axis, only return values for configs where mask==True. b_partial_e might have a smaller configs axis than epos, _configscurrent, and _b_partial because of the mask.
         """
-        nelec = np.sum(self._mol.nelec)
         nup = self._mol.nelec[0]
         sep = nup - int(e < nup)
-        not_e = np.arange(nelec) != e
+        not_e = np.arange(self._nelec) != e
         edown = int(e >= nup)
         d = epos.dist.dist_i(
             self._configscurrent.configs[mask][:, not_e], epos.configs[mask]

--- a/pyqmc/jastrowspin.py
+++ b/pyqmc/jastrowspin.py
@@ -222,6 +222,8 @@ class JastrowSpin:
         not_e = np.arange(nelec) != e
         dnew = epos.dist.dist_i(self._configscurrent.configs, epos.configs)[:, not_e]
         dinew = epos.dist.dist_i(self._mol.atom_coords(), epos.configs)
+        rnew = np.linalg.norm(dnew, axis=-1)
+        rinew = np.linalg.norm(dinew, axis=-1)
 
         grad = np.zeros((3, nconf))
 
@@ -230,12 +232,12 @@ class JastrowSpin:
         edown = int(e >= nup)
 
         for c, b in zip(self.parameters["bcoeff"], self.b_basis):
-            bgrad = b.gradient(dnew)
+            bgrad = b.gradient(dnew, rnew)
             grad += c[edown] * np.sum(bgrad[:, :nup - eup], axis=1).T
             grad += c[1 + edown] * np.sum(bgrad[:, nup - eup:], axis=1).T
 
         for c, a in zip(self.parameters["acoeff"].transpose()[edown], self.a_basis):
-            grad += np.einsum("j,ijk->ki", c, a.gradient(dinew))
+            grad += np.einsum("j,ijk->ki", c, a.gradient(dinew, rinew))
 
         return grad
 
@@ -248,6 +250,8 @@ class JastrowSpin:
         not_e = np.arange(nelec) != e 
         dnew = epos.dist.dist_i(self._configscurrent.configs, epos.configs)[:, not_e]
         dinew = epos.dist.dist_i(self._mol.atom_coords(), epos.configs)
+        rnew = np.linalg.norm(dnew, axis=-1)
+        rinew = np.linalg.norm(dinew, axis=-1)
 
         eup = int(e < nup)
         edown = int(e >= nup)
@@ -256,13 +260,13 @@ class JastrowSpin:
         lap = np.zeros(nconf)
         # a-value component
         for c, a in zip(self.parameters["acoeff"].transpose()[edown], self.a_basis):
-            grad += np.einsum("j,ijk->ki", c, a.gradient(dinew))
-            lap += np.einsum("j,ijk->i", c, a.laplacian(dinew))
+            g, l = a.gradient_laplacian(dinew, rinew)
+            grad += np.einsum("j,ijk->ki", c, g)
+            lap += np.einsum("j,ijk->i", c, l)
 
         # b-value component
         for c, b in zip(self.parameters["bcoeff"], self.b_basis):
-            bgrad = b.gradient(dnew)
-            blap = b.laplacian(dnew)
+            bgrad, blap = b.gradient_laplacian(dnew, rnew)
             grad += c[edown] * np.sum(bgrad[:, :nup - eup], axis=1).T
             grad += c[1 + edown] * np.sum(bgrad[:, nup - eup:], axis=1).T
             lap += c[edown] * np.sum(blap[:, :nup - eup], axis=(1, 2))

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -87,5 +87,5 @@ def test_func3d():
 
 
 if __name__ == "__main__":
-    #test_wfs()
+    test_wfs()
     test_func3d()

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -63,6 +63,7 @@ def test_func3d():
         CutoffCuspFunction,
         test_func3d_gradient,
         test_func3d_laplacian,
+        test_func3d_gradient_laplacian,
     )
 
     test_functions = {
@@ -77,11 +78,14 @@ def test_func3d():
     for name, func in test_functions.items():
         grad = test_func3d_gradient(func, delta=delta)[0]
         lap =  test_func3d_laplacian(func, delta=delta)[0]
-        print(name, grad, lap)
-        assert  grad < epsilon
+        andg, andl = test_func3d_gradient_laplacian(func)
+        print(name, grad, lap, "both:", andg, andl)
+        assert grad < epsilon
         assert lap < epsilon
+        assert andg < epsilon
+        assert andl < epsilon
 
 
 if __name__ == "__main__":
-    test_wfs()
+    #test_wfs()
     test_func3d()

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -70,6 +70,7 @@ def test_func3d():
         test_func3d_gradient,
         test_func3d_laplacian,
         test_func3d_gradient_laplacian,
+        test_func3d_pgradient,
     )
 
     test_functions = {
@@ -85,11 +86,15 @@ def test_func3d():
         grad = test_func3d_gradient(func, delta=delta)[0]
         lap = test_func3d_laplacian(func, delta=delta)[0]
         andg, andl = test_func3d_gradient_laplacian(func)
+        pgrad = test_func3d_pgradient(func, delta=1e-9)[0]
         print(name, grad, lap, "both:", andg, andl)
+        print(name, pgrad)
         assert grad < epsilon
         assert lap < epsilon
         assert andg < epsilon
         assert andl < epsilon
+        for k, v in pgrad.items():
+            assert v < epsilon, (name, k, v)
 
 
 if __name__ == "__main__":

--- a/tests/test_vmc.py
+++ b/tests/test_vmc.py
@@ -41,7 +41,7 @@ def test_vmc():
         en = df.mean()
         err = df.sem()
         assert en - mf.energy_tot() < 5 * err, "pyscf {0}, vmc {1}, err {2}".format(
-            en, mf.enery_tot(), err
+            en, mf.energy_tot(), err
         )
 
 


### PR DESCRIPTION
This pull request includes several changes to condense and speed up the jastrow code (mostly in the basis functions). The speedup seems to be up to 5%, mostly from passing distances r to all func3d functions.

- Pass distances r as input to every func3d function to avoid redundant norm calculations
- Added function gradient_laplacian to all basis functions to combine gradient and laplacian computations
- Added test for basis function pgradient
- Fixed bug in CutoffCuspFunction.pgradient for parameter rcut
- Mask inputs by (r <= rcut) for all functions in PolyPadeFunction and CutoffCuspFunction
- Small speed improvements by rearranging arithmetic
- Condensed code to make shorter and more readable