### PR TITLE
Update PySCFSlaterUHF._aovals in updateinternals()

### DIFF
--- a/pyqmc/slateruhf.py
+++ b/pyqmc/slateruhf.py
@@ -150,6 +150,7 @@ class PySCFSlaterUHF:
             mask = [True] * epos.configs.shape[0]
         eeff = e - s * self._nelec[0]
         ao = self._mol.eval_gto(self.pbc_str + "GTOval_sph", epos.configs)
+        self._aovals[:, e, :] = ao
         mo = ao.dot(self.parameters[self._coefflookup[s]])
         ratio, self._inverse[s][mask, :, :] = sherman_morrison_row(
             eeff, self._inverse[s][mask, :, :], mo[mask, :]


### PR DESCRIPTION
PySCFSlaterUHF._aovals is set in recompute() and used in pgradient(), but not updated in updateinternals. The derivative test uses recompute() for the numerical derivative, so this doesn't come up in the test.

This change updates _aovals in updateinternals, but doesn't change the test.