### PR TITLE
Bug fix for dask VMC with multiple epochs.

### DIFF
--- a/pyqmc/dasktools.py
+++ b/pyqmc/dasktools.py
@@ -59,7 +59,7 @@ def distvmc(
             pyqmc.vmc,
             wfs,
             thiscoord,
-            **{"nsteps": nsteps_per, "accumulators": accumulators, "stepoffset": epoch},
+            **{"nsteps": nsteps_per, "accumulators": accumulators, "stepoffset": epoch*nsteps_per},
             **kwargs
         )
         iterdata = []


### PR DESCRIPTION
Simple change: the later epochs have their first step shifted by the number of steps in the previous epochs rather than by the number of previous epochs. Otherwise the steps are not labeled correctly when there is more than one epoch.