### PR TITLE
Added an option for ion cusps.

### DIFF
--- a/pyqmc/__init__.py
+++ b/pyqmc/__init__.py
@@ -87,13 +87,13 @@ def default_jastrow(mol,ion_cusp=False):
 
     jastrow = JastrowSpin(mol, a_basis=abasis, b_basis=bbasis)
     if ion_cusp:
-        jastrow.parameters["acoeff"][:,0, [0, 1]] = mol.atom_charges()[None]
+        jastrow.parameters["acoeff"][:,0, :] = mol.atom_charges()[:,None]
     jastrow.parameters["bcoeff"][0, [0, 1, 2]] = np.array([-0.25, -0.50, -0.25])
 
     freeze = {}
     freeze["acoeff"] = np.zeros(jastrow.parameters["acoeff"].shape).astype(bool)
     if ion_cusp:
-        freeze["acoeff"][0, [0, 1]] = True  # Cusp conditions
+        freeze["acoeff"][:,0,:] = True  # Cusp conditions
     freeze["bcoeff"] = np.zeros(jastrow.parameters["bcoeff"].shape).astype(bool)
     freeze["bcoeff"][0, [0, 1, 2]] = True  # Cusp conditions
     to_opt = ["acoeff", "bcoeff"]

--- a/pyqmc/__init__.py
+++ b/pyqmc/__init__.py
@@ -87,10 +87,7 @@ def default_jastrow(mol,ion_cusp=False):
 
     jastrow = JastrowSpin(mol, a_basis=abasis, b_basis=bbasis)
     if ion_cusp:
-        # I don't think the current format allows for cusps on each atom to be different. 
-        # Would need to adjust the constructor for Jastrow to allow difference coefficients for each atom probably.
-        assert len(set([mol.atom_symbol(i) for i in range(mol.natm)]))==1, "ion_cusp only implemented for one atom type."
-        jastrow.parameters["acoeff"][0, [0, 1]] = mol.atom_charge(0)
+        jastrow.parameters["acoeff"][:,0, [0, 1]] = mol.atom_charges()[None]
     jastrow.parameters["bcoeff"][0, [0, 1, 2]] = np.array([-0.25, -0.50, -0.25])
 
     freeze = {}


### PR DESCRIPTION
Ion cusps can be added for the `default_jastrow` by setting `ion_cusp=True`. Defaults to off.

Here's a graphical check. This is the result of running `line_minimization` with `ion_cusp=True` and freezing the ion and electron cusps. The system is H-He with 2 electrons, one at the origin and one along the z axis. 

[check_elocal.pdf](https://github.com/WagnerGroup/pyqmc/files/3848713/check_elocal.pdf)
