### PR TITLE
Dmc test reblocking

### DIFF
--- a/tests/test_dmc.py
+++ b/tests/test_dmc.py
@@ -49,7 +49,7 @@ def test():
     dfdmc, configs_, weights_ = rundmc(
         wf,
         configs,
-        nsteps=1600 + warmup,
+        nsteps=4000 + warmup,
         branchtime=5,
         accumulators={"energy": EnergyAccumulator(mol)},
         ekey=("energy", "total"),

--- a/tests/test_dmc.py
+++ b/tests/test_dmc.py
@@ -45,10 +45,11 @@ def test():
         np.std(dfvmc["energytotal"]) / np.sqrt(len(dfvmc)),
     )
 
+    warmup = 200
     dfdmc, configs_, weights_ = rundmc(
         wf,
         configs,
-        nsteps=1800,
+        nsteps=1600 + warmup,
         branchtime=5,
         accumulators={"energy": EnergyAccumulator(mol)},
         ekey=("energy", "total"),
@@ -60,8 +61,7 @@ def test():
     dfdmc = pd.DataFrame(dfdmc)
     dfdmc.sort_values("step", inplace=True)
 
-    warmup = 200
-    dfprod = dfdmc[dfdmc.step > warmup]
+    dfprod = dfdmc[dfdmc.step >= warmup]
 
     rb_summary = reblock.reblock_summary(dfprod[["energytotal", "energyei"]], 20)
     print(rb_summary)

--- a/tests/test_dmc.py
+++ b/tests/test_dmc.py
@@ -62,8 +62,8 @@ def test():
 
     warmup = 200
     dfprod = dfdmc[dfdmc.step > warmup]
-    
-    rb_summary = reblock.optimally_reblocked(dfprod[["energytotal", "energyei"]])
+
+    rb_summary = reblock.reblock_summary(dfprod[["energytotal", "energyei"]], 20)
     print(rb_summary)
     energy, err = [rb_summary[v]["energytotal"] for v in ("mean", "standard error")]
     assert (


### PR DESCRIPTION
Changed reblocking in test_dmc to use 20 blocks instead of optimally_reblocked, which sometimes didn't find an optimal number of reblocks. Increased number of steps to 4000 plus 200 warmup.