### PR TITLE
make initial_guess assign core electrons even when none are left over

### DIFF
--- a/pyqmc/mc.py
+++ b/pyqmc/mc.py
@@ -46,17 +46,15 @@ def initial_guess(mol, nconfig, r=1.0):
         )  # fraction of electron unassigned on each atom
         nassigned = np.sum(neach)  # number of electrons assigned
         totleft = int(mol.nelec[s] - nassigned)  # number of electrons not yet assigned
+        ind0 = s * mol.nelec[0]
+        epos[:, ind0 : ind0 + nassigned, :] = np.repeat(
+            mol.atom_coords(), neach, axis=0
+        )  # assign core electrons
         if totleft > 0:
             bins = np.cumsum(nleft) / totleft
             inds = np.argpartition(
                 np.random.random((nconfig, len(wts))), totleft, axis=1
             )[:, :totleft]
-            ind0 = s * mol.nelec[0]
-            epos[:, ind0 : ind0 + nassigned, :] = np.repeat(
-                mol.atom_coords(), neach, axis=0
-            )[
-                np.newaxis
-            ]  # assign core electrons
             epos[:, ind0 + nassigned : ind0 + mol.nelec[s], :] = mol.atom_coords()[
                 inds
             ]  # assign remaining electrons


### PR DESCRIPTION
When no electrons are "left over", the core assignments were not made (the electrons were distributed around the origin instead of around atom centers. This pull request fixes issue #137, which was caused by very poor initial guesses for large systems. 