### PR TITLE
Create hdf interface in Configs objects

### DIFF
--- a/pyqmc/coord.py
+++ b/pyqmc/coord.py
@@ -63,11 +63,23 @@ class OpenConfigs:
     def copy(self):
         return copy.deepcopy(self)
 
+    def initialize_hdf(self, hdf):
+        hdf.create_dataset("configs", self.configs.shape)
+
+    def to_hdf(self, hdf):
+        hdf["configs"][:, :, :] = self.configs
+
+    def load_hdf(self, hdf):
+        self.configs = np.array(hdf["configs"])
+
 
 class PeriodicConfigs:
     def __init__(self, configs, lattice_vectors, wrap=None):
+        configs, wrap_ = enforce_pbc(lattice_vectors, configs)
         self.configs = configs
-        self.wrap = np.zeros(configs.shape) if wrap is None else wrap
+        self.wrap = wrap_
+        if wrap is not None:
+            self.wrap += wrap
         self.lvecs = lattice_vectors
         self.dist = MinimalImageDistance(lattice_vectors)
 
@@ -131,6 +143,18 @@ class PeriodicConfigs:
 
     def copy(self):
         return copy.deepcopy(self)
+
+    def initialize_hdf(self, hdf):
+        hdf.create_dataset("configs", self.configs.shape)
+        hdf.create_dataset("wrap", self.wrap.shape)
+
+    def to_hdf(self, hdf):
+        hdf["configs"][:, :, :] = self.configs
+        hdf["wrap"][:, :, :] = self.wrap
+
+    def load_hdf(self, hdf):
+        self.configs = np.array(hdf["configs"])
+        self.wrap = np.array(hdf["wrap"])
 
 
 def test():

--- a/pyqmc/dmc.py
+++ b/pyqmc/dmc.py
@@ -230,12 +230,12 @@ def dmc_file(hdf_file, data, attr, configs, weights):
         with h5py.File(hdf_file, "a") as hdf:
             if "configs" not in hdf.keys():
                 hdftools.setup_hdf(hdf, data.loc[0], attr)
-                hdf.create_dataset("configs", configs.configs.shape)
+                configs.initialize_hdf(hdf)
             if "weights" not in hdf.keys():
                 hdf.create_dataset("weights", weights.shape)
             for i in range(len(data)):
                 hdftools.append_hdf(hdf, data.loc[i])
-            hdf["configs"][:, :, :] = configs.configs
+            configs.to_hdf(hdf)
             hdf["weights"][:] = weights
 
 
@@ -296,7 +296,7 @@ def rundmc(
     if hdf_file is not None:
         with h5py.File(hdf_file, "a") as hdf:
             if "configs" in hdf.keys():
-                configs.configs = np.array(hdf["configs"])
+                configs.load_hdf(hdf)
                 weights = np.array(hdf["weights"])
                 if verbose:
                     print("Restarted calculation")

--- a/pyqmc/mc.py
+++ b/pyqmc/mc.py
@@ -92,9 +92,9 @@ def vmc_file(hdf_file, data, attr, configs):
         with h5py.File(hdf_file, "a") as hdf:
             if "configs" not in hdf.keys():
                 hdftools.setup_hdf(hdf, data, attr)
-                hdf.create_dataset("configs", configs.configs.shape)
+                configs.initialize_hdf(hdf)
             hdftools.append_hdf(hdf, data)
-            hdf["configs"][:, :, :] = configs.configs
+            configs.to_hdf(hdf)
 
 
 def vmc(
@@ -140,7 +140,7 @@ def vmc(
     if hdf_file is not None:
         with h5py.File(hdf_file, "a") as hdf:
             if "configs" in hdf.keys():
-                configs.configs = np.array(hdf["configs"])
+                configs.load_hdf(hdf)
                 if verbose:
                     print("Restarted calculation")
 


### PR DESCRIPTION
OpenConfigs and PeriodicConfigs have three new functions that take in an h5py.File object:
initialize_hdf(hdf): call hdf.create_dataset() for each attribute (configs, wrap, etc)
to_hdf(hdf): write the current attributes to hdf
load_hdf(hdf): overwrite attributes with values from hdf

vmc, dmc, and linemin now load and save configs using this interface.