### PR TITLE
fix pbc error in eval_ecp.get_r_ea_i and check for atoms with ecps

### DIFF
--- a/pyqmc/__init__.py
+++ b/pyqmc/__init__.py
@@ -1,6 +1,7 @@
 name = "pyqmc"
 from pyqmc.mc import vmc, initial_guess
 from pyqmc.slateruhf import PySCFSlaterUHF
+from pyqmc.slaterpbc import PySCFSlaterPBC
 from pyqmc.multislater import MultiSlater
 
 from pyqmc.multiplywf import MultiplyWF
@@ -62,6 +63,7 @@ def default_slater(mol, mf, optimize_orbitals=False):
         to_opt = []
         freeze = {}
     return wf, to_opt, freeze
+
 
 def default_multislater(mol, mf, mc, tol=None):
     import numpy as np

--- a/pyqmc/jastrowspin.py
+++ b/pyqmc/jastrowspin.py
@@ -48,6 +48,7 @@ class JastrowSpin:
         self._mol = mol
         self.parameters["bcoeff"] = np.zeros((nexpand, 3))
         self.parameters["acoeff"] = np.zeros((self._mol.natm, aexpand, 2))
+        self.iscomplex = False
 
     def recompute(self, configs):
         r"""

--- a/pyqmc/multiplywf.py
+++ b/pyqmc/multiplywf.py
@@ -59,6 +59,7 @@ class MultiplyWF:
     def __init__(self, *wf_factors):
         self.wf_factors = [*wf_factors]
         self.parameters = Parameters([wf.parameters for wf in wf_factors])
+        self.iscomplex = bool(sum(wf.iscomplex for wf in wf_factors))
 
     def recompute(self, configs):
         signs = np.ones(len(configs.configs))

--- a/pyqmc/multislater.py
+++ b/pyqmc/multislater.py
@@ -25,6 +25,7 @@ def binary_to_occ(S, ncore):
     max_orb = max(occup)
     return (occup, max_orb)
 
+
 class MultiSlater:
     """
     A multi-determinant wave function object initialized
@@ -33,9 +34,9 @@ class MultiSlater:
     """
 
     def __init__(self, mol, mf, mc, tol=None):
-        if(tol is None): 
+        if tol is None:
             self.tol = -1
-        else: 
+        else:
             self.tol = tol
         self.parameters = {}
         self._mol = mol
@@ -50,6 +51,11 @@ class MultiSlater:
             self.parameters["mo_coeff_beta"] = mc.mo_coeff[:, : mc.ncas + mc.ncore]
         self._coefflookup = ("mo_coeff_alpha", "mo_coeff_beta")
         self.pbc_str = "PBC" if hasattr(mol, "a") else ""
+        self.iscomplex = bool(sum(map(np.iscomplexobj, self.parameters.values())))
+        if self.iscomplex:
+            self.get_phase = lambda x: x / np.abs(x)
+        else:
+            self.get_phase = np.sign
 
     def _copy_ci(self, mc):
         """       
@@ -65,12 +71,12 @@ class MultiSlater:
         # find multi slater determinant occupation
         detwt = []
         deters = fci.addons.large_ci(mc.ci, norb, nelec, tol=-1)
-        
+
         # Create map and occupation objects
         map_dets = [[], []]
         occup = [[], []]
         for x in deters:
-            if(np.abs(x[0]) > self.tol):
+            if np.abs(x[0]) > self.tol:
                 detwt.append(x[0])
                 alpha_occ, __ = binary_to_occ(x[1], ncore)
                 beta_occ, __ = binary_to_occ(x[2], ncore)

--- a/pyqmc/slaterpbc.py
+++ b/pyqmc/slaterpbc.py
@@ -113,7 +113,12 @@ class PySCFSlaterPBC:
             scale = np.linalg.det(self.supercell.S)
             self._nelec = [int(np.round(n * scale)) for n in self._cell.nelec]
         self._nelec = tuple(self._nelec)
-        self.get_phase = lambda x: np.exp(2j * np.pi * np.angle(x))
+        self.iscomplex = bool(sum(map(np.iscomplexobj, self.parameters.values())))
+        self.iscomplex = self.iscomples or np.linalg.norm(self._kpts) > 1e-12
+        if self.iscomplex:
+            self.get_phase = lambda x: x / np.abs(x)
+        else:
+            self.get_phase = np.sign
 
     def evaluate_orbitals(self, configs, mask=None, eval_str="PBCGTOval_sph"):
         mycoords = configs.configs

--- a/pyqmc/slaterpbc.py
+++ b/pyqmc/slaterpbc.py
@@ -114,7 +114,7 @@ class PySCFSlaterPBC:
             self._nelec = [int(np.round(n * scale)) for n in self._cell.nelec]
         self._nelec = tuple(self._nelec)
         self.iscomplex = bool(sum(map(np.iscomplexobj, self.parameters.values())))
-        self.iscomplex = self.iscomples or np.linalg.norm(self._kpts) > 1e-12
+        self.iscomplex = self.iscomplex or np.linalg.norm(self._kpts) > 1e-12
         if self.iscomplex:
             self.get_phase = lambda x: x / np.abs(x)
         else:

--- a/pyqmc/slateruhf.py
+++ b/pyqmc/slateruhf.py
@@ -95,13 +95,9 @@ class PySCFSlaterUHF:
                     :, np.asarray(mf.mo_occ > 1.1)
                 ]
 
-        if (
-            np.iscomplexobj(
-                np.concatenate([p.ravel() for p in self.parameters.values()])
-            )
-            or np.linalg.norm(twist) != 0
-        ):
-            self.get_phase = lambda x: np.exp(2j * np.pi * np.angle(x))
+        self.iscomplex = bool(sum(map(np.iscomplexobj, self.parameters.values())))
+        if self.iscomplex:
+            self.get_phase = lambda x: x / np.abs(x)
         else:
             self.get_phase = np.sign
         self._coefflookup = ("mo_coeff_alpha", "mo_coeff_beta")


### PR DESCRIPTION
This fixes an error in the nonlocal part of the ecp calculation for pbcs, where get_r_ea_i didn't use a pbc distance calculator. 

This PR also includes a check for whether each atom atom is in the ecp dict, so ecps can be used for a subset of atomic species.