### PR TITLE
Periodic multislater and periodic parameter gradients

### DIFF
--- a/pyqmc/manybody_jastrow.py
+++ b/pyqmc/manybody_jastrow.py
@@ -9,6 +9,7 @@ class J3:
         self.parameters = {}
         self.parameters["gcoeff"] = np.zeros((dim, dim))
         self.iscomplex = False
+        self.optimize = "greedy"
 
     def recompute(self, configs):
         self._configscurrent = configs.copy()
@@ -38,7 +39,7 @@ class J3:
             self.ao_val,
             self.ao_val,
             mask,
-            optimize="greedy",
+            optimize=self.optimize,
         )
         signs = np.ones(len(vals))
         return (signs, vals)
@@ -50,14 +51,14 @@ class J3:
             self.parameters["gcoeff"],
             e_grad[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         grad2 = np.einsum(
             "mn, cim, dcn -> dc",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_grad[:, :, 0, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         return grad1 + grad2
 
@@ -68,14 +69,14 @@ class J3:
             self.parameters["gcoeff"],
             e_lap[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         lap2 = np.einsum(
             "mn, cim, dcn -> c",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_lap[:, :, 0, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
 
         grad1 = np.einsum(
@@ -83,14 +84,14 @@ class J3:
             self.parameters["gcoeff"],
             e_grad[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         grad2 = np.einsum(
             "mn, cim, dcn -> dc",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_grad[:, :, 0, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         grad = grad1 + grad2
 
@@ -104,14 +105,14 @@ class J3:
             self.parameters["gcoeff"],
             e_lap[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         lap2 = np.einsum(
             "mn, cim, dcn -> c",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_lap[:, :, 0, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
 
         grad1 = np.einsum(
@@ -119,14 +120,14 @@ class J3:
             self.parameters["gcoeff"],
             e_grad[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         grad2 = np.einsum(
             "mn, cim, dcn -> dc",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_grad[:, :, 0, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         grad = grad1 + grad2
 
@@ -138,7 +139,7 @@ class J3:
             np.ones((self.nelec, self.nelec)), -1
         )  # to prevent double counting of electron pairs
         coeff_grad = np.einsum(
-            "cim, cjn, ij-> cmn", self.ao_val, self.ao_val, mask, optimize="greedy"
+            "cim, cjn, ij-> cmn", self.ao_val, self.ao_val, mask, optimize=self.optimize
         )
         return {"gcoeff": coeff_grad}
 
@@ -181,14 +182,14 @@ class J3:
             self.parameters["gcoeff"],
             masked_ao_val[:, e, :],
             masked_ao_val[:, :e, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         curr_val += np.einsum(
             "mn, cim, cn -> c",
             self.parameters["gcoeff"],
             masked_ao_val[:, e + 1 :, :],
             masked_ao_val[:, e, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
 
         new_ao_val = self._get_val_grad_lap(epos, mode="val", mask=mask)
@@ -197,14 +198,14 @@ class J3:
             self.parameters["gcoeff"],
             new_ao_val,
             masked_ao_val[:, :e, :],
-            optimize="greedy",
+            optimize=self.optimize,
         )
         new_val += np.einsum(
             "mn, cim, c...n -> c...",
             self.parameters["gcoeff"],
             masked_ao_val[:, e + 1 :, :],
             new_ao_val,
-            optimize="greedy",
+            optimize=self.optimize,
         )
 
         return np.exp((new_val.T - curr_val).T)

--- a/pyqmc/manybody_jastrow.py
+++ b/pyqmc/manybody_jastrow.py
@@ -8,6 +8,7 @@ class J3:
         dim = mol.eval_gto("GTOval_cart", randpos).shape[-1]
         self.parameters = {}
         self.parameters["gcoeff"] = np.zeros((dim, dim))
+        self.iscomplex = False
 
     def recompute(self, configs):
         self._configscurrent = configs.copy()
@@ -37,7 +38,7 @@ class J3:
             self.ao_val,
             self.ao_val,
             mask,
-            optimize='greedy'
+            optimize="greedy",
         )
         signs = np.ones(len(vals))
         return (signs, vals)
@@ -49,14 +50,14 @@ class J3:
             self.parameters["gcoeff"],
             e_grad[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         grad2 = np.einsum(
             "mn, cim, dcn -> dc",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_grad[:, :, 0, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         return grad1 + grad2
 
@@ -67,14 +68,14 @@ class J3:
             self.parameters["gcoeff"],
             e_lap[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         lap2 = np.einsum(
             "mn, cim, dcn -> c",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_lap[:, :, 0, :],
-            optimize='greedy'
+            optimize="greedy",
         )
 
         grad1 = np.einsum(
@@ -82,14 +83,14 @@ class J3:
             self.parameters["gcoeff"],
             e_grad[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         grad2 = np.einsum(
             "mn, cim, dcn -> dc",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_grad[:, :, 0, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         grad = grad1 + grad2
 
@@ -103,14 +104,14 @@ class J3:
             self.parameters["gcoeff"],
             e_lap[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         lap2 = np.einsum(
             "mn, cim, dcn -> c",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_lap[:, :, 0, :],
-            optimize='greedy'
+            optimize="greedy",
         )
 
         grad1 = np.einsum(
@@ -118,14 +119,14 @@ class J3:
             self.parameters["gcoeff"],
             e_grad[:, :, 0, :],
             self.ao_val[:, :e, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         grad2 = np.einsum(
             "mn, cim, dcn -> dc",
             self.parameters["gcoeff"],
             self.ao_val[:, e + 1 :, :],
             e_grad[:, :, 0, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         grad = grad1 + grad2
 
@@ -136,7 +137,9 @@ class J3:
         mask = np.tril(
             np.ones((self.nelec, self.nelec)), -1
         )  # to prevent double counting of electron pairs
-        coeff_grad = np.einsum("cim, cjn, ij-> cmn", self.ao_val, self.ao_val, mask, optimize='greedy')
+        coeff_grad = np.einsum(
+            "cim, cjn, ij-> cmn", self.ao_val, self.ao_val, mask, optimize="greedy"
+        )
         return {"gcoeff": coeff_grad}
 
     def _get_val_grad_lap(self, configs, mode="lap", mask=None):
@@ -178,14 +181,14 @@ class J3:
             self.parameters["gcoeff"],
             masked_ao_val[:, e, :],
             masked_ao_val[:, :e, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         curr_val += np.einsum(
             "mn, cim, cn -> c",
             self.parameters["gcoeff"],
             masked_ao_val[:, e + 1 :, :],
             masked_ao_val[:, e, :],
-            optimize='greedy'
+            optimize="greedy",
         )
 
         new_ao_val = self._get_val_grad_lap(epos, mode="val", mask=mask)
@@ -194,14 +197,14 @@ class J3:
             self.parameters["gcoeff"],
             new_ao_val,
             masked_ao_val[:, :e, :],
-            optimize='greedy'
+            optimize="greedy",
         )
         new_val += np.einsum(
             "mn, cim, c...n -> c...",
             self.parameters["gcoeff"],
             masked_ao_val[:, e + 1 :, :],
             new_ao_val,
-            optimize='greedy'
+            optimize="greedy",
         )
 
         return np.exp((new_val.T - curr_val).T)

--- a/pyqmc/multislater.py
+++ b/pyqmc/multislater.py
@@ -304,8 +304,8 @@ class MultiSlater:
         return ratios
 
     def pgradient(self):
-        """Compute the parameter gradient of Psi. 
-        Returns d_p \Psi/\Psi as a dictionary of numpy arrays,
+        r"""Compute the parameter gradient of Psi. 
+        Returns :math:`\frac{\partial_p \Psi}{\Psi}` as a dictionary of numpy arrays,
         which correspond to the parameter dictionary."""
         d = {}
 

--- a/pyqmc/multislaterpbc.py
+++ b/pyqmc/multislaterpbc.py
@@ -1,0 +1,342 @@
+import numpy as np
+from pyqmc.multislater import sherman_morrison_ms
+from pyqmc.slaterpbc import get_supercell_kpts
+from pyqmc import pbc
+
+
+class MultiSlaterPBC:
+    """
+    A multi-determinant wave function object initialized
+    via an SCF calculation. Methods and structure are very similar
+    to the PySCFSlaterUHF class.
+    """
+
+    def __init__(
+        self, supercell, mf, tol=-1, detwt=(1,), occup=None, map_dets=None, twist=None
+    ):
+        """
+        detwt: list of determinant weights
+        occup: list (spin, det, dict{kind: occupation list})
+        map_dets: list (spin, ndet) to identify which determinant of each spin to use (e.g. may use the same up-determinant in multiple products)
+        """
+        for attribute in ["original_cell", "S"]:
+            if not hasattr(supercell, attribute):
+                print('Warning: supercell is missing attribute "%s"' % attribute)
+                print("setting original_cell=supercell and S=np.eye(3)")
+                supercell.original_cell = supercell
+                supercell.S = np.eye(3)
+
+        assert occup is not None
+        assert len(map_dets[0]) == len(detwt) and len(map_dets[1]) == len(detwt)
+        self.parameters = {"det_coeff": np.array(detwt)}
+
+        self.tol = tol
+        self.real_tol = 1e4
+        self._mol = supercell.original_cell
+        self._nelec = tuple(int(sum(len(v) for v in o[0].values())) for o in occup)
+
+        self.supercell = supercell
+        if twist is None:
+            twist = np.zeros(3)
+        else:
+            twist = np.dot(np.linalg.inv(supercell.a), np.mod(twist, 1.0)) * 2 * np.pi
+        self._kpts = get_supercell_kpts(supercell) + twist
+        kdiffs = mf.kpts[np.newaxis] - self._kpts[:, np.newaxis]
+        self.kinds = np.nonzero(np.linalg.norm(kdiffs, axis=-1) < 1e-12)[1]
+        self.nk = len(self._kpts)
+        print("nk", self.nk, self.kinds)
+
+        maxorb = [
+            {
+                k: np.amax([np.amax(list(d[k]) + [-1]) for d in o]) + 1
+                for k in self.kinds
+            }
+            for o in occup
+        ]
+
+        self.parameters["mo_coeff_alpha"] = []
+        self.parameters["mo_coeff_beta"] = []
+        for kind in self.kinds:
+            if len(mf.mo_coeff[0][0].shape) == 2:
+                mca = mf.mo_coeff[0][kind][:, : maxorb[0][kind]]
+                mcb = mf.mo_coeff[1][kind][:, : maxorb[1][kind]]
+            else:
+                mca = mf.mo_coeff[kind][:, : maxorb[0][kind]]
+                mcb = mf.mo_coeff[kind][:, : maxorb[1][kind]]
+            mca = np.real_if_close(mca, tol=self.real_tol)
+            mcb = np.real_if_close(mcb, tol=self.real_tol)
+            self.parameters["mo_coeff_alpha"].append(mca / np.sqrt(self.nk))
+            self.parameters["mo_coeff_beta"].append(mcb / np.sqrt(self.nk))
+        self._coefflookup = ("mo_coeff_alpha", "mo_coeff_beta")
+
+        # _det_occup: Spin, [(Ndet_up_unique, nup), (Ndet_dn_unique, ndn)]
+        self._det_occup = [
+            np.zeros((len(o), n), dtype=int) for o, n in zip(occup, self._nelec)
+        ]
+        for s, o in enumerate(occup):
+            orb_inds = np.cumsum([0] + [maxorb[s][k] for k in self.kinds[:-1]])
+            for d, det in enumerate(o):
+                self._det_occup[s][d] = np.concatenate(
+                    [np.array(det[k]) + ind for k, ind in zip(self.kinds, orb_inds)]
+                )
+        self._det_map = np.asarray(map_dets)  # Spin, N_det
+        print("det_coeff", self.parameters["det_coeff"])
+        print("_det_occup\n", self._det_occup)
+        print("_det_map\n", self._det_map)
+
+        self.iscomplex = np.linalg.norm(self._kpts) > 1e-12
+        for v in self.parameters.values():
+            self.iscomplex = self.iscomplex or bool(sum(map(np.iscomplexobj, v)))
+        if self.iscomplex:
+            self.get_phase = lambda x: x / np.abs(x)
+            self.get_wrapphase = lambda x: np.exp(1j * x)
+        else:
+            self.get_phase = np.sign
+            self.get_wrapphase = lambda x: (-1) ** np.round(x / np.pi)
+
+    def evaluate_orbitals(self, configs, mask=None, eval_str="PBCGTOval_sph"):
+        mycoords = configs.configs
+        configswrap = configs.wrap
+        if mask is not None:
+            mycoords = mycoords[mask]
+            configswrap = configswrap[mask]
+        mycoords = mycoords.reshape((-1, mycoords.shape[-1]))
+        # wrap supercell positions into primitive cell
+        prim_coords, prim_wrap = pbc.enforce_pbc(self._mol.lattice_vectors(), mycoords)
+        configswrap = configswrap.reshape(prim_wrap.shape)
+        wrap = prim_wrap + np.dot(configswrap, self.supercell.S)
+        kdotR = np.linalg.multi_dot((self._kpts, self._mol.lattice_vectors().T, wrap.T))
+        wrap_phase = self.get_wrapphase(kdotR)
+        # evaluate AOs for all electron positions
+        ao = self._mol.eval_gto(eval_str, prim_coords, kpts=self._kpts)
+        ao = [ao[k] * wrap_phase[k][:, np.newaxis] for k in range(self.nk)]
+        return ao
+
+    def evaluate_mos(self, aos, s):
+        p = self.parameters[self._coefflookup[s]]
+        mo = [np.dot(ao, p[k]) for k, ao in enumerate(aos)]
+        mo = np.concatenate(mo, axis=-1)
+        return mo[..., self._det_occup[s]]
+
+    def recompute(self, configs):
+        """This computes the value from scratch. Returns the logarithm of the wave function as
+        (phase,logdet). If the wf is real, phase will be +/- 1."""
+        nconf, nelec, ndim = configs.configs.shape
+        aos = self.evaluate_orbitals(configs)
+        aos = np.reshape(aos, (self.nk, nconf, nelec, -1))
+        self._aovals = aos
+        self._dets = []
+        self._inverse = []
+        for s in [0, 1]:
+            i0, i1 = s * self._nelec[0], self._nelec[0] + s * self._nelec[1]
+            mo_vals = self.evaluate_mos(aos[:, :, i0:i1], s).swapaxes(1, 2)
+            self._dets.append(np.array(np.linalg.slogdet(mo_vals)))
+            self._inverse.append(np.linalg.inv(mo_vals))
+        return self.value()
+
+    def updateinternals(self, e, epos, mask=None):
+        """Update any internals given that electron e moved to epos. mask is a Boolean array 
+        which allows us to update only certain walkers"""
+        s = int(e >= self._nelec[0])
+        if mask is None:
+            mask = [True] * epos.configs.shape[0]
+        eeff = e - s * self._nelec[0]
+        aos = self.evaluate_orbitals(epos)
+        self._aovals[:, :, e, :] = np.asarray(aos)
+        mo = self.evaluate_mos(aos, s)
+        ratio, self._inverse[s][mask] = sherman_morrison_ms(
+            eeff, self._inverse[s][mask], mo[mask, :]
+        )
+        self._updateval(ratio, s, mask)
+
+    # identical to multislater.py
+    def value(self):
+        """Return logarithm of the wave function as noted in recompute()"""
+        wf_val = 0
+        wf_sign = 0
+
+        wf_val = np.einsum(
+            "d,di->i",
+            self.parameters["det_coeff"],
+            self._dets[0][0, :, self._det_map[0]]
+            * self._dets[1][0, :, self._det_map[1]]
+            * np.exp(
+                self._dets[0][1, :, self._det_map[0]]
+                + self._dets[1][1, :, self._det_map[1]]
+            ),
+        )
+
+        wf_sign = self.get_phase(wf_val)
+        wf_val = np.log(np.abs(wf_val))
+        return wf_sign, wf_val
+
+    # identical to slateruhf
+    def _updateval(self, ratio, s, mask):
+        self._dets[s][0, mask, :] *= self.get_phase(ratio)
+        self._dets[s][1, mask, :] += np.log(np.abs(ratio))
+
+    # identical to multislater.py
+    def _testrow(self, e, vec, mask=None, spin=None):
+        """vec is a nconfig,nmo vector which replaces row e"""
+        if spin is None:
+            s = int(e >= self._nelec[0])
+        else:
+            s = spin
+
+        if mask is None:
+            mask = [True] * vec.shape[0]
+
+        ratios = np.einsum(
+            "i...dj,idj...->i...d",
+            vec,
+            self._inverse[s][mask][..., e - s * self._nelec[0]],
+        )
+        det_array = (
+            self._dets[0][0, :, self._det_map[0]][:, mask]
+            * self._dets[1][0, :, self._det_map[1]][:, mask]
+            * np.exp(
+                self._dets[0][1, :, self._det_map[0]][:, mask]
+                + self._dets[1][1, :, self._det_map[1]][:, mask]
+            )
+        )
+        numer = np.einsum(
+            "i...d,d,di->i...",
+            ratios[..., self._det_map[s]],
+            self.parameters["det_coeff"],
+            det_array,
+        )
+
+        curr_val = self.value()
+        denom = curr_val[0][mask] * np.exp(curr_val[1][mask])
+        if len(numer.shape) == 2:
+            denom = denom[:, np.newaxis]
+        return numer / denom
+
+    # identical to multislater.py
+    def _testcol(self, det, i, s, vec):
+        """vec is a nconfig,nmo vector which replaces column i 
+        of spin s in determinant det"""
+
+        ratio = np.einsum("ij,ij->i", vec, self._inverse[s][:, det, i, :])
+        return ratio
+
+    # identical to slaterpbc
+    def testvalue(self, e, epos, mask=None):
+        """ return the ratio between the current wave function and the wave function if 
+        electron e's position is replaced by epos"""
+        s = int(e >= self._nelec[0])
+        if mask is None:
+            mask = [True] * epos.configs.shape[0]
+        nmask = np.sum(mask)
+        if nmask == 0:
+            return np.zeros((0, epos.configs.shape[1]))
+        ao = self.evaluate_orbitals(epos, mask=mask)
+        mo = self.evaluate_mos(ao, s)
+        mo = mo.reshape((nmask, *epos.configs.shape[1:-1], -1, self._nelec[s]))
+        return self._testrow(e, mo, mask)
+
+    # identical to slaterpbc
+    def testvalue_many(self, e, epos, mask=None):
+        """ return the ratio between the current wave function and the wave function if 
+        electron e's position is replaced by epos for each electron"""
+        s = (e >= self._nelec[0]).astype(int)
+        if mask is None:
+            mask = [True] * epos.configs.shape[0]
+        nmask = np.sum(mask)
+        if nmask == 0:
+            return np.zeros((0, epos.configs.shape[1]))
+
+        ao = self.evaluate_orbitals(epos, mask=mask)
+        ratios = np.zeros(
+            (epos.configs.shape[0], e.shape[0]),
+            dtype=complex if self.iscomplex else float,
+        )
+        for spin in [0, 1]:
+            ind = s == spin
+            mo = self.evaluate_mos(aos, spin)
+            mo = mo.reshape(nmask, *epos.configs.shape[1:-1], -1, self._nelec[spin])
+            ratios[:, ind] = self._testrow(e[ind], mo, mask=mask, spin=spin)
+        return ratios
+
+    # identical to slaterpbc
+    def gradient(self, e, epos):
+        """ Compute the gradient of the log wave function 
+        Note that this can be called even if the internals have not been updated for electron e,
+        if epos differs from the current position of electron e."""
+        s = int(e >= self._nelec[0])
+        aograd = self.evaluate_orbitals(epos, eval_str="PBCGTOval_sph_deriv1")
+        mograd = self.evaluate_mos(aograd, s)
+        ratios = np.asarray([self._testrow(e, x) for x in mograd])
+        return ratios[1:] / ratios[:1]
+
+    # identical to slaterpbc
+    def laplacian(self, e, epos):
+        """ Compute the laplacian Psi/ Psi. """
+        s = int(e >= self._nelec[0])
+        ao = self.evaluate_orbitals(epos, eval_str="PBCGTOval_sph_deriv2")
+        aostack = [np.stack([ak[0], ak[[4, 7, 9]].sum(axis=0)], axis=0) for ak in ao]
+        molap = self.evaluate_mos(aostack, s)
+        ratios = np.asarray([self._testrow(e, x) for x in molap])
+        return ratios[1] / ratios[0]
+
+    # identical to slaterpbc
+    def gradient_laplacian(self, e, epos):
+        s = int(e >= self._nelec[0])
+        ao = self.evaluate_orbitals(epos, eval_str="PBCGTOval_sph_deriv2")
+        aostack = [
+            np.concatenate([ak[0:4], ak[[4, 7, 9]].sum(axis=0, keepdims=True)], axis=0)
+            for ak in ao
+        ]
+        mo_vals = self.evaluate_mos(aostack, s)
+        ratios = np.asarray([self._testrow(e, x) for x in mo_vals])
+        return ratios[1:-1] / ratios[:1], ratios[-1] / ratios[0]
+
+    def pgradient(self):
+        """Compute the parameter gradient of Psi. 
+        Returns d_p \Psi/\Psi as a dictionary of numpy arrays,
+        which correspond to the parameter dictionary."""
+        d = {}
+
+        ## Det coeff
+        # det_coeff_grad = (
+        #     self._dets[0][0, :, self._det_map[0]]
+        #     * self._dets[1][0, :, self._det_map[1]]
+        #     * np.exp(
+        #         self._dets[0][1, :, self._det_map[0]]
+        #         + self._dets[1][1, :, self._det_map[1]]
+        #     )
+        # )
+
+        # curr_val = self.value()
+        # d["det_coeff"] = (
+        #     det_coeff_grad.T / (curr_val[0] * np.exp(curr_val[1]))[:, np.newaxis]
+        # )
+
+        ## Mo_coeff, adapted from SlaterUHF
+        # for parm in ["mo_coeff_alpha", "mo_coeff_beta"]:
+        #     s = 0
+        #     if "beta" in parm:
+        #         s = 1
+
+        #     ao = self._aovals[
+        #         :, :, s * self._nelec[0] : self._nelec[s] + s * self._nelec[0], :
+        #     ]
+        #     pgrad_shape = (ao.shape[0],) + self.parameters[parm].shape
+        #     pgrad = np.zeros(pgrad_shape)
+
+        #     largest_mo = np.max(np.ravel(self._det_occup[s]))
+        #     for i in range(largest_mo + 1):  # MO loop
+        #         for det in range(self.parameters["det_coeff"].shape[0]):  # Det loop
+        #             if (
+        #                 i in self._det_occup[s][self._det_map[s][det]]
+        #             ):  # Check if MO in det
+        #                 col = self._det_occup[s][self._det_map[s][det]].index(i)
+        #                 for j in range(ao.shape[2]):
+        #                     vec = ao[:, :, j]
+        #                     pgrad[:, j, i] += (
+        #                         self.parameters["det_coeff"][det]
+        #                         * d["det_coeff"][:, det]
+        #                         * self._testcol(self._det_map[s][det], col, s, vec)
+        #                     )
+        #     d[parm] = np.array(pgrad)
+        return d

--- a/pyqmc/multislaterpbc.py
+++ b/pyqmc/multislaterpbc.py
@@ -292,8 +292,8 @@ class MultiSlaterPBC:
         return ratios[1:-1] / ratios[:1], ratios[-1] / ratios[0]
 
     def pgradient(self):
-        """Compute the parameter gradient of Psi. 
-        Returns d_p \Psi/\Psi as a dictionary of numpy arrays,
+        r"""Compute the parameter gradient of Psi. 
+        Returns :math:`\frac{\partial_p \Psi}{\Psi}` as a dictionary of numpy arrays,
         which correspond to the parameter dictionary."""
         d = {}
 

--- a/pyqmc/slaterpbc.py
+++ b/pyqmc/slaterpbc.py
@@ -217,7 +217,7 @@ class PySCFSlaterPBC:
         if mask is None:
             return np.einsum("i...j,ij...->i...", vec, self._inverse[s][:, :, elec])
 
-        return np.einsum("i...j,ij...->i...", vec, self._inverse[s][mask, :, elec])
+        return np.einsum("i...j,ij...->i...", vec, self._inverse[s][mask][:, :, elec])
 
     # identical to slateruhf
     def _testcol(self, i, s, vec):
@@ -229,9 +229,7 @@ class PySCFSlaterPBC:
         """ return the ratio between the current wave function and the wave function if 
         electron e's position is replaced by epos"""
         s = int(e >= self._nelec[0])
-        if mask is None:
-            mask = [True] * epos.configs.shape[0]
-        nmask = np.sum(mask)
+        nmask = epos.configs.shape[0] if mask is None else np.sum(mask)
         if nmask == 0:
             return np.zeros((0, epos.configs.shape[1]))
         aos = self.evaluate_orbitals(epos, mask)
@@ -243,9 +241,7 @@ class PySCFSlaterPBC:
         """ return the ratio between the current wave function and the wave function if 
         an electron's position is replaced by epos for each electron"""
         s = (e >= self._nelec[0]).astype(int)
-        if mask is None:
-            mask = [True] * epos.configs.shape[0]
-        nmask = np.sum(mask)
+        nmask = epos.configs.shape[0] if mask is None else np.sum(mask)
         if nmask == 0:
             return np.zeros((0, epos.configs.shape[1]))
 

--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -123,10 +123,8 @@ def test_wf_pgradient(wf, configs, delta=1e-5):
             flt[i] += delta
             wf.parameters[k] = flt.reshape(wf.parameters[k].shape)
 
-        error[k] = (
-            np.amax(np.abs(gradient[k].reshape((-1, nparms)) - numgrad)),
-            np.mean(np.abs(gradient[k].reshape((-1, nparms)) - numgrad)),
-        )
+        pgerr = np.abs(gradient[k].reshape((-1, nparms)) - numgrad)
+        error[k] = (np.amax(pgerr), np.mean(pgerr))
     if len(error) == 0:
         return (0, 0)
     return error[max(error)]  # Return maximum coefficient error

--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -3,13 +3,6 @@ import time
 import numpy as np
 
 
-def is_complex(wf):
-    cond1 = hasattr(wf, "nk")
-    cond2 = hasattr(wf, "wf1") and is_complex(wf.wf1)
-    cond3 = hasattr(wf, "wf2") and is_complex(wf.wf2)
-    return cond1 or cond2 or cond3
-
-
 def test_mask(wf, e, epos, mask=None):
     # testvalue
     if mask is None:
@@ -36,7 +29,7 @@ def test_updateinternals(wf, configs):
     nconf, ne, ndim = configs.configs.shape
     delta = 1e-2
 
-    iscomplex = 1j if is_complex(wf) else 1
+    iscomplex = 1j if wf.iscomplex else 1
     updatevstest = np.zeros((ne, nconf)) * iscomplex
     recomputevstest = np.zeros((ne, nconf)) * iscomplex
     recomputevsupdate = np.zeros((ne, nconf)) * iscomplex
@@ -81,7 +74,7 @@ def test_wf_gradient(wf, configs, delta=1e-5):
     
     """
     nconf, nelec = configs.configs.shape[0:2]
-    iscomplex = 1j if is_complex(wf) else 1
+    iscomplex = 1j if wf.iscomplex else 1
     wf.recompute(configs)
     maxerror = 0
     grad = np.zeros(configs.configs.shape) * iscomplex
@@ -107,7 +100,7 @@ def test_wf_gradient(wf, configs, delta=1e-5):
 
 
 def test_wf_pgradient(wf, configs, delta=1e-5):
-    iscomplex = 1j if is_complex(wf) else 1
+    iscomplex = 1j if wf.iscomplex else 1
     baseval = wf.recompute(configs)
     gradient = wf.pgradient()
     error = {}
@@ -154,7 +147,7 @@ def test_wf_laplacian(wf, configs, delta=1e-5):
     wf.laplacian(e,epos) should behave the same as gradient, except lap(Psi(epos))/Psi(epos)
     """
     nconf, nelec = configs.configs.shape[0:2]
-    iscomplex = 1j if is_complex(wf) else 1
+    iscomplex = 1j if wf.iscomplex else 1
     wf.recompute(configs)
     maxerror = 0
     lap = np.zeros(configs.configs.shape[:2]) * iscomplex
@@ -185,7 +178,7 @@ def test_wf_laplacian(wf, configs, delta=1e-5):
 
 def test_wf_gradient_laplacian(wf, configs):
     nconf, nelec = configs.configs.shape[0:2]
-    iscomplex = 1j if is_complex(wf) else 1
+    iscomplex = 1j if wf.iscomplex else 1
     wf.recompute(configs)
     maxerror = 0
     lap = np.zeros(configs.configs.shape[:2]) * iscomplex

--- a/tests/unit/test_derivatives.py
+++ b/tests/unit/test_derivatives.py
@@ -19,7 +19,6 @@ def test_wfs():
     from pyqmc.slateruhf import PySCFSlaterUHF
     from pyqmc.jastrowspin import JastrowSpin
     from pyqmc.multiplywf import MultiplyWF
-    from pyqmc.multiplynwf import MultiplyNWF
     from pyqmc.coord import OpenConfigs
     from pyqmc.manybody_jastrow import J3
     import pyqmc
@@ -35,7 +34,7 @@ def test_wfs():
         JastrowSpin(mol),
         J3(mol),
         MultiplyWF(PySCFSlaterUHF(mol, mf), JastrowSpin(mol)),
-        MultiplyNWF([PySCFSlaterUHF(mol, mf), JastrowSpin(mol), J3(mol)]),
+        MultiplyWF(PySCFSlaterUHF(mol, mf), JastrowSpin(mol), J3(mol)),
         PySCFSlaterUHF(mol, mf_uhf),
         PySCFSlaterUHF(mol, mf),
         PySCFSlaterUHF(mol, mf_rohf),

--- a/tests/unit/test_derivatives.py
+++ b/tests/unit/test_derivatives.py
@@ -71,29 +71,42 @@ def test_pbc_wfs():
 
     from pyscf.pbc import lib, gto, scf
     from pyqmc.slaterpbc import PySCFSlaterPBC, get_supercell
+    from pyqmc.multislaterpbc import MultiSlaterPBC
     from pyqmc.jastrowspin import JastrowSpin
     from pyqmc.multiplywf import MultiplyWF
     from pyqmc.coord import OpenConfigs
     import pyqmc
 
     mol = gto.M(
-        atom="H 0. 0. 0.; H 1. 1. 1.", basis="sto-3g", unit="bohr", a=np.eye(3) * 4
+        atom="H 0. 0. 0.; H 1. 1. 1.",
+        basis="sto-3g",
+        unit="bohr",
+        a=(np.ones((3, 3)) - np.eye(3)) * 4,
     )
-    mf = scf.KRKS(mol).run()
+    mf = scf.KRKS(mol, mol.make_kpts((2, 2, 2))).run()
     # mf_rohf = scf.KROKS(mol).run()
     # mf_uhf = scf.KUKS(mol).run()
     epsilon = 1e-5
     nconf = 10
-    supercell = get_supercell(mol, S=np.eye(3))
+    supercell = get_supercell(mol, S=(np.ones((3, 3)) - 2 * np.eye(3)))
     epos = pyqmc.initial_guess(supercell, nconf)
+    # For multislaterpbc
+    kinds = 0, 3, 5, 6  # G, X, Y, Z
+    d1 = {kind: [0] for kind in kinds}
+    d2 = d1.copy()
+    d2.update({0: [], 3: [0, 1]})
+    detwt = [2 ** 0.5, 2 ** 0.5]
+    occup = [[d1, d2], [d1]]
+    map_dets = [[0, 1], [0, 0]]
     for wf in [
-        MultiplyWF(PySCFSlaterPBC(supercell, mf), JastrowSpin(mol)),
+        MultiplyWF(PySCFSlaterPBC(supercell, mf), JastrowSpin(supercell)),
         PySCFSlaterPBC(supercell, mf),
+        MultiSlaterPBC(supercell, mf, detwt=detwt, occup=occup, map_dets=map_dets),
         # PySCFSlaterPBC(supercell, mf_uhf),
         # PySCFSlaterPBC(supercell, mf_rohf),
     ]:
         for k in wf.parameters:
-            if "mo_coeff" not in k:
+            if "mo_coeff" not in k and k != "det_coeff":
                 wf.parameters[k] = np.random.rand(*wf.parameters[k].shape)
         for fname, func in zip(
             ["gradient", "laplacian", "pgradient"],


### PR DESCRIPTION
Implemented MultiSlaterPBC and test. Also includes parameter gradients and passes test. 

For parameter gradients, I changed the parameters from list of kpoints to an array of MO coefficients concatenated over kpoints (for both SlaterPBC and MultiSlaterPBC) just like is done to construct determinants. Using a numpy array makes pgradient compatible with our other functions.

Added function evaluate_mos to SlaterPBC and MultiSlaterPBC to simplify the code in testvalue, gradient, etc. 