### PR TITLE
fix twist bug; kpoints are periodic

### DIFF
--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -51,7 +51,7 @@ class LinearTransform:
     def __init__(self, parameters, to_opt=None):
         if to_opt is None:
             to_opt = {k: np.ones(p.shape, dtype=bool) for k, p in parameters.items()}
-        self.to_opt = to_opt
+        self.to_opt = {k: o for k, o in to_opt.items() if np.any(o)}
 
         self.frozen_parms = {k: parameters[k][~opt] for k, opt in self.to_opt.items()}
 

--- a/pyqmc/multislaterpbc.py
+++ b/pyqmc/multislaterpbc.py
@@ -1,5 +1,6 @@
 import numpy as np
 from pyqmc.multislater import sherman_morrison_ms
+from pyqmc.slater import get_kinds
 from pyqmc.supercell import get_supercell_kpts
 from pyqmc import pbc
 
@@ -40,9 +41,9 @@ class MultiSlaterPBC:
             twist = np.zeros(3)
         else:
             twist = np.dot(np.linalg.inv(supercell.a), np.mod(twist, 1.0)) * 2 * np.pi
-        self._kpts = get_supercell_kpts(supercell) + twist
-        kdiffs = mf.kpts[np.newaxis] - self._kpts[:, np.newaxis]
-        self.kinds = np.nonzero(np.linalg.norm(kdiffs, axis=-1) < 1e-12)[1]
+        self.kinds = get_kinds(self._cell, mf, get_supercell_kpts(cell) + twist)
+        self._kpts = mf.kpts[self.kinds]
+        assert len(self.kinds) == len(self._kpts), (self._kpts, mf.kpts)
         self.nk = len(self._kpts)
         print("nk", self.nk, self.kinds)
 

--- a/pyqmc/multislaterpbc.py
+++ b/pyqmc/multislaterpbc.py
@@ -41,7 +41,7 @@ class MultiSlaterPBC:
             twist = np.zeros(3)
         else:
             twist = np.dot(np.linalg.inv(supercell.a), np.mod(twist, 1.0)) * 2 * np.pi
-        self.kinds = get_kinds(self._cell, mf, get_supercell_kpts(cell) + twist)
+        self.kinds = get_kinds(self._mol, mf, get_supercell_kpts(supercell) + twist)
         self._kpts = mf.kpts[self.kinds]
         assert len(self.kinds) == len(self._kpts), (self._kpts, mf.kpts)
         self.nk = len(self._kpts)

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -134,7 +134,7 @@ class PySCFSlater:
                 int(np.sum([mf.mo_occ[k] > t for k in self.kinds])) for t in (0.9, 1.1)
             ]
         else:
-            print("Warning: not expecting scf object of type", type(mf))
+            print("Warning: PySCFSlater not expecting scf object of type", type(mf))
             scale = self.supercell.scale
             self._nelec = [int(np.round(n * scale)) for n in self._cell.nelec]
         self._nelec = tuple(self._nelec)


### PR DESCRIPTION
short fix: twist was just added to kpoints and compared against mf.kpts; if it was a reciprocal lattice vector away, it would result in an error. This PR fixes the error by checking if the differences are zero modulo reciprocal lattice vectors.