### PR TITLE
Defaults

### DIFF
--- a/pyqmc/__init__.py
+++ b/pyqmc/__init__.py
@@ -94,11 +94,11 @@ def default_jastrow(mol, ion_cusp=None, na=4, nb=3, rcut=None):
         if not mol.has_ecp():
             print("Warning: using neither ECP nor ion_cusp")
     elif ion_cusp == True:
-        ion_cusp = list(mol.basis.keys())
+        ion_cusp = list(mol._basis.keys())
         if mol.has_ecp():
             print("Warning: using both ECP and ion_cusp")
     elif ion_cusp is None:
-        ion_cusp = [l for l in mol.basis.keys() if l not in mol._ecp.keys()]
+        ion_cusp = [l for l in mol._basis.keys() if l not in mol._ecp.keys()]
         print("default ion_cusp:", ion_cusp)
     else:
         assert isinstance(ion_cusp, list)

--- a/pyqmc/__init__.py
+++ b/pyqmc/__init__.py
@@ -107,9 +107,9 @@ def default_jastrow(mol, ion_cusp=None, na=4, nb=3, rcut=None):
         abasis = [CutoffCuspFunction(gamma=24, rcut=rcut)]
     else:
         abasis = []
-    abasis += [PolyPadeFunction(beta=beta_abasis[i], rcut=rcut) for i in range(4)]
+    abasis += [PolyPadeFunction(beta=ba, rcut=rcut) for ba in beta_abasis]
     bbasis = [CutoffCuspFunction(gamma=24, rcut=rcut)]
-    bbasis += [PolyPadeFunction(beta=beta_bbasis[i], rcut=rcut) for i in range(3)]
+    bbasis += [PolyPadeFunction(beta=bb, rcut=rcut) for bb in beta_bbasis]
 
     jastrow = JastrowSpin(mol, a_basis=abasis, b_basis=bbasis)
     if len(ion_cusp) > 0:

--- a/pyqmc/__init__.py
+++ b/pyqmc/__init__.py
@@ -60,7 +60,7 @@ def default_multislater(mol, mf, mc, tol=None, optimize_orbitals=False):
     return wf, to_opt
 
 
-def default_jastrow(mol, ion_cusp=None, na=4, nb=3, rcut=7.5):
+def default_jastrow(mol, ion_cusp=None, na=4, nb=3, rcut=None):
     """         
     Default 2-body jastrow from qwalk,
     Args:
@@ -80,6 +80,12 @@ def default_jastrow(mol, ion_cusp=None, na=4, nb=3, rcut=7.5):
         for i in range(1, n):
             beta[i] = np.exp(beta1 + 1.6 * i) - 1
         return beta
+
+    if rcut is None:
+        if hasattr(mol, "a"):
+            rcut = np.amin(np.pi / np.linalg.norm(mol.reciprocal_vectors(), axis=1))
+        else:
+            rcut = 7.5
 
     beta_abasis = expand_beta_qwalk(0.2, na)
     beta_bbasis = expand_beta_qwalk(0.5, nb)

--- a/pyqmc/__init__.py
+++ b/pyqmc/__init__.py
@@ -36,9 +36,9 @@ def gradient_generator(mol, wf, to_opt=None, **ewald_kwargs):
     )
 
 
-def default_slater(mol, mf, optimize_orbitals=False):
+def default_slater(mol, mf, optimize_orbitals=False, twist=None):
 
-    wf = PySCFSlater(mol, mf)
+    wf = PySCFSlater(mol, mf, twist=twist)
     to_opt = {}
     if optimize_orbitals:
         for k in ["mo_coeff_alpha", "mo_coeff_beta"]:
@@ -137,9 +137,9 @@ def default_msj(mol, mf, mc, tol=None, freeze_orb=None, ion_cusp=False):
     return wf, to_opt
 
 
-def default_sj(mol, mf, ion_cusp=False):
-    wf1, to_opt1 = default_slater(mol, mf)
-    wf2, to_opt2 = default_jastrow(mol, ion_cusp)
+def default_sj(mol, mf, optimize_orbitals=False, twist=None, **jastrow_kws):
+    wf1, to_opt1 = default_slater(mol, mf, optimize_orbitals, twist)
+    wf2, to_opt2 = default_jastrow(mol, **jastrow_kws)
     wf = MultiplyWF(wf1, wf2)
     to_opt = {"wf1" + x: opt for x, opt in to_opt1.items()}
     to_opt.update({"wf2" + x: opt for x, opt in to_opt2.items()})


### PR DESCRIPTION
let default_jastrow decide what ion_cusps to set based on ecps
let default_jastrow choose rcut based on lattice
pass kwargs `optimize_orbitals` and `twist` through default_sj and default_slater
remove hard-coded 3 and 4 that should be set by kwargs na and nb