### PR TITLE
Reorganize reblock.py

### DIFF
--- a/pyqmc/reblock.py
+++ b/pyqmc/reblock.py
@@ -18,7 +18,6 @@ def reblock(df, nblocks):
         vals = np.array_split(array, nblocks, axis=0)
         return [v.mean(axis=0) for v in vals]
 
-    size, nbig = np.divmod(len(df), nblocks)
     if isinstance(df, pd.Series):
         return pd.Series(_reblock(df.values, nblocks))
     elif isinstance(df, pd.DataFrame):

--- a/pyqmc/reblock.py
+++ b/pyqmc/reblock.py
@@ -8,9 +8,16 @@ def reblock(df, nblocks):
 
     :param df: data to reblock
     :type df: pandas DataFrame, Series, or numpy array
+    :param nblocks: number of resulting blocks
+    :type nblocks: int
     :return: reblocked data
     :rtype: same as input df
     """
+
+    def _reblock(array, nblocks):
+        vals = np.array_split(array, nblocks, axis=0)
+        return [v.mean(axis=0) for v in vals]
+
     size, nbig = np.divmod(len(df), nblocks)
     if isinstance(df, pd.Series):
         return pd.Series(_reblock(df.values, nblocks))
@@ -34,18 +41,6 @@ def reblock_summary(df, nblocks):
         "n_blocks": nblocks,
     }
     return pd.DataFrame(d)
-
-
-def _reblock(array, nblocks):
-    """
-    This is a helper method to reblock(). 
-    :param array: data to reblock along axis 0
-    :type array: numpy array
-    :return: reblocked data
-    :rtype: list
-    """
-    vals = np.array_split(array, nblocks, axis=0)
-    return [v.mean(axis=0) for v in vals]
 
 
 def optimally_reblocked(data):

--- a/pyqmc/reblock.py
+++ b/pyqmc/reblock.py
@@ -14,10 +14,6 @@ def reblock(df, nblocks):
     :rtype: same as input df
     """
 
-    def _reblock(array, nblocks):
-        vals = np.array_split(array, nblocks, axis=0)
-        return [v.mean(axis=0) for v in vals]
-
     if isinstance(df, pd.Series):
         return pd.Series(_reblock(df.values, nblocks))
     elif isinstance(df, pd.DataFrame):
@@ -28,6 +24,14 @@ def reblock(df, nblocks):
     else:
         print("WARNING: can't reblock data of type", type(df), "-- not reblocking.")
         return df
+
+
+def _reblock(array, nblocks):
+    """
+    Helper function to reblock(); this function actually does the reblocking.
+    """
+    vals = np.array_split(array, nblocks, axis=0)
+    return [v.mean(axis=0) for v in vals]
 
 
 def reblock_summary(df, nblocks):


### PR DESCRIPTION
moved functions around so that the ones most likely to be used are at the top
added a couple docstrings
moved _reblock() inside of reblock() to avoid confusion

looks like the other functions (i.e. optimally_reblocked and its helpers) still work as intended.