### PR TITLE
add functions keys() and shapes() to accumulators

### DIFF
--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -39,6 +39,12 @@ class EnergyAccumulator:
             d[k] = np.mean(it, axis=0)
         return d
 
+    def keys(self):
+        return set(["ke", "ee", "ei", "ecp", "total"])
+
+    def shapes(self):
+        return {"ke": (), "ee": (), "ei": (), "ecp": (), "total": ()}
+
 
 class LinearTransform:
     """
@@ -168,6 +174,15 @@ class PGradTransform:
 
         return d
 
+    def keys(self):
+        return self.enacc.keys().union(["dpH", "dppsi", "dpidpj"])
+
+    def shapes(self):
+        nparms = np.sum([np.sum(opt) for opt in self.transform.to_opt.values()])
+        d = {"dpH": (nparms,), "dppsi": (nparms,), "dpidpj": (nparms, nparms)}
+        d.update(self.enacc.shapes())
+        return d
+
 
 class SqAccumulator:
     r"""
@@ -204,3 +219,9 @@ class SqAccumulator:
 
     def avg(self, configs, wf):
         return {k: np.mean(it, axis=0) for k, it in self(configs, wf).items()}
+
+    def keys(self):
+        return set(["Sq"])
+
+    def shapes(self):
+        return {"Sq": (len(self.qlist),)}

--- a/pyqmc/obdm.py
+++ b/pyqmc/obdm.py
@@ -78,6 +78,10 @@ class OBDMAccumulator:
             ), "orb_coeff should be a list of orbital coefficients."
 
         self._orb_coeff = orb_coeff
+        if hasattr(self._orb_coeff, "shape"):
+            self.norb = self._orb_coeff.shape[1]
+        else:
+            self.norb = sum(c.shape[1] for c in self._orb_coeff)
         self._tstep = tstep
         self.nelec = len(self._electrons)
         self._nsweeps = nsweeps
@@ -93,15 +97,10 @@ class OBDMAccumulator:
         """ Quantities from equation (9) of DOI:10.1063/1.4793531"""
 
         nconf = configs.configs.shape[0]
-        if hasattr(self._orb_coeff, "shape"):
-            norb = self._orb_coeff.shape[1]
-        else:
-            norb = sum(c.shape[1] for c in self._orb_coeff)
+        dtype = complex if self.iscomplex else float
         results = {
-            "value": np.zeros(
-                (nconf, norb, norb), dtype=complex if self.iscomplex else float
-            ),
-            "norm": np.zeros((nconf, norb)),
+            "value": np.zeros((nconf, self.norb, self.norb), dtype=dtype),
+            "norm": np.zeros((nconf, self.norb)),
             "acceptance": np.zeros(nconf),
         }
         acceptance = 0
@@ -150,12 +149,7 @@ class OBDMAccumulator:
         return results
 
     def avg(self, configs, wf):
-        d = self(configs, wf)
-        davg = {}
-        for k, v in d.items():
-            # print(k, v.shape)
-            davg[k] = np.mean(v, axis=0)
-        return davg
+        return {k: np.mean(it, axis=0) for k, it in self(configs, wf).items()}
 
     def get_extra_configs(self, configs):
         """ Returns an nstep length array of configurations
@@ -212,6 +206,13 @@ class OBDMAccumulator:
         ao = [aok * wrap_phase[k][:, np.newaxis] for k, aok in enumerate(ao)]
         borb = [aok.dot(ock) for aok, ock in zip(ao, self._orb_coeff)]
         return np.concatenate(borb, axis=1)
+
+    def keys(self):
+        return set(["value", "norm", "acceptance"])
+
+    def shapes(self):
+        norb = self.norb
+        return {"value": (norb, norb), "norm": (norb,), "acceptance": ()}
 
 
 def sample_onebody(mol, orb_coeff, configs, tstep=2.0):

--- a/pyqmc/tbdm.py
+++ b/pyqmc/tbdm.py
@@ -235,11 +235,10 @@ class TBDMAccumulator:
             d["acceptance_%s" % e] = ()
         return d
 
-    def information(self):
-        return {"ijkl": self._ijkl.T}
-
     def avg(self, configs, wf):
-        return {k: np.mean(it, axis=0) for k, it in self(configs, wf).items()}
+        d = {k: np.mean(it, axis=0) for k, it in self(configs, wf).items()}
+        d["ijkl"] = self._ijkl.T
+        return d
 
     def get_extra_configs(self, configs):
         """ Returns an nstep length array of configurations

--- a/pyqmc/tbdm.py
+++ b/pyqmc/tbdm.py
@@ -225,14 +225,21 @@ class TBDMAccumulator:
 
         return results
 
+    def keys(self):
+        return set(["value", "norm_a", "norm_b", "acceptance_a", "acceptance_b"])
+
+    def shapes(self):
+        d = {"value": (self._ijkl.shape[1],)}
+        for e, s in zip(["a", "b"], self._spin_sector):
+            d["norm_%s" % e] = (self._orb_coeff[s].shape[1],)
+            d["acceptance_%s" % e] = ()
+        return d
+
+    def information(self):
+        return {"ijkl": self._ijkl.T}
+
     def avg(self, configs, wf):
-        d = self(configs, wf)
-        davg = {}
-        for k, v in d.items():
-            # print(k, v.shape)
-            davg[k] = np.mean(v, axis=0)
-        davg["ijkl"] = self._ijkl.T
-        return davg
+        return {k: np.mean(it, axis=0) for k, it in self(configs, wf).items()}
 
     def get_extra_configs(self, configs):
         """ Returns an nstep length array of configurations

--- a/pyqmc/tbdm.py
+++ b/pyqmc/tbdm.py
@@ -226,10 +226,12 @@ class TBDMAccumulator:
         return results
 
     def keys(self):
-        return set(["value", "norm_a", "norm_b", "acceptance_a", "acceptance_b"])
+        return set(
+            ["value", "norm_a", "norm_b", "acceptance_a", "acceptance_b", "ijkl"]
+        )
 
     def shapes(self):
-        d = {"value": (self._ijkl.shape[1],)}
+        d = {"value": (self._ijkl.shape[1],), "ijkl": self._ijkl.T.shape}
         for e, s in zip(["a", "b"], self._spin_sector):
             d["norm_%s" % e] = (self._orb_coeff[s].shape[1],)
             d["acceptance_%s" % e] = ()

--- a/tests/unit/test_accumulators.py
+++ b/tests/unit/test_accumulators.py
@@ -1,6 +1,8 @@
 import numpy as np
 from pyqmc.energy import energy
 from pyqmc.accumulators import LinearTransform
+from pyqmc.obdm import OBDMAccumulator
+import pyqmc
 
 
 def test_transform():
@@ -8,7 +10,6 @@ def test_transform():
     TODO: figure out a thing to test.
     """
     from pyscf import gto, scf
-    import pyqmc
 
     r = 1.54 / 0.529177
     mol = gto.M(
@@ -34,5 +35,64 @@ def test_transform():
     assert gradtrans.shape[0] == nconfig
 
 
+def test_info_functions_mol():
+    from pyscf import gto, scf
+    from pyqmc.tbdm import TBDMAccumulator
+
+    mol = gto.Mole()
+    mol.atom = """He 0.00 0.00 0.00 """
+    mol.basis = "ccpvdz"
+    mol.build()
+
+    mf = scf.RHF(mol)
+    ehf = mf.kernel()
+
+    wf, to_opt = pyqmc.default_sj(mol, mf)
+    accumulators = {
+        "pgrad": pyqmc.gradient_generator(mol, wf, to_opt),
+        "obdm": OBDMAccumulator(mol, orb_coeff=mf.mo_coeff),
+        "tbdm_updown": TBDMAccumulator(mol, np.asarray([mf.mo_coeff] * 2), (0, 1)),
+    }
+    info_functions(mol, wf, accumulators)
+
+
+def test_info_functions_pbc():
+    from pyscf.pbc import gto, scf
+    from pyqmc.supercell import get_supercell
+
+    mol = gto.Cell(atom="He 0.00 0.00 0.00", basis="ccpvdz", unit="B")
+    mol.a = 5.61 * np.eye(3)
+    mol.build()
+
+    mf = scf.KRHF(mol, kpts=mol.make_kpts([2, 2, 2])).density_fit()
+    ehf = mf.kernel()
+
+    supercell = get_supercell(mol, 2 * np.eye(3))
+    kinds = [0, 1]
+    dm_orbs = [mf.mo_coeff[i][:, :2] for i in kinds]
+    wf, to_opt = pyqmc.default_sj(mol, mf)
+    accumulators = {
+        "pgrad": pyqmc.gradient_generator(mol, wf, to_opt, ewald_gmax=10),
+        "obdm": OBDMAccumulator(mol, dm_orbs, kpts=mf.kpts[kinds]),
+        "Sq": pyqmc.accumulators.SqAccumulator(mol.lattice_vectors()),
+    }
+    info_functions(mol, wf, accumulators)
+
+
+def info_functions(mol, wf, accumulators):
+    accumulators["energy"] = accumulators["pgrad"].enacc
+    configs = pyqmc.initial_guess(mol, 100)
+    wf.recompute(configs)
+    for k, acc in accumulators.items():
+        shapes = acc.shapes()
+        keys = acc.keys()
+        assert shapes.keys() == keys, "keys: {0}\nshapes: {1}".format(keys, shapes)
+        avg = acc.avg(configs, wf)
+        assert avg.keys() == keys, (k, avg.keys(), keys)
+        for ka in keys:
+            assert shapes[ka] == avg[ka].shape, "{0} {1}".format(ka, avg[ka].shape)
+
+
 if __name__ == "__main__":
-    test_transform()
+    test_info_functions_mol()
+    test_info_functions_pbc()


### PR DESCRIPTION
Addressing issue #175 Accumulator functions

Energy, PGrad, OBDM, TBDM, Sq now all have the functions:
keys(): returns a set
shapes(): returns a dict whose keys are keys() and values are shapes. scalars have shape ()

I changed the definition of avg() in obdm and tbdm to the one-line version, since it does the same thing.
In tbdm I moved "ijkl" from avg() to a new function information(). I'm still not sure why we don't just use tbdm_acc._ijkl to get the array.