### PR TITLE
separate complex parameters in LinearTransform

### DIFF
--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -64,13 +64,21 @@ class LinearTransform:
         self.shapes = {k: parameters[k].shape for k in self.to_opt}
         self.slices = {k: np.prod(s) for k, s in self.shapes.items()}
         self.dtypes = {k: parameters[k].dtype for k in self.to_opt}
+        self.complex = {k: d == complex for k, d in self.dtypes.items()}
+        self.nimag = {k: to_opt[k].sum() if c else 0 for k, c in self.complex.items()}
+        self.complex_inds = np.concatenate(
+            [np.ones(to_opt[k].sum(), dtype=bool) * c for k, c in self.complex.items()]
+        )
+        self.nparams = np.sum([v.sum() for v in self.to_opt.values()])
 
     def serialize_parameters(self, parameters):
         """Convert the dictionary to a linear list
         of gradients
         """
-        params = [parameters[k][opt] for k, opt in self.to_opt.items()]
-        return np.concatenate(params)
+        for k, opt in self.to_opt.items():
+            print(k, opt.shape, parameters[k].shape)
+        params = np.concatenate([parameters[k][opt] for k, opt in self.to_opt.items()])
+        return np.concatenate((params.real, params[self.complex_inds].imag))
 
     def serialize_gradients(self, pgrad):
         """Convert the dictionary to a linear list
@@ -81,12 +89,17 @@ class LinearTransform:
             mask = ~np.repeat(opt[np.newaxis, :], pgrad[k].shape[0], axis=0)
             mask_grads = np.ma.array(pgrad[k], mask=mask).reshape(pgrad[k].shape[0], -1)
             grads.append(np.ma.compress_cols(mask_grads))
-        return np.concatenate(grads, axis=1)
+
+        grads = np.concatenate(grads, axis=1)
+        return np.concatenate(
+            (grads.real, grads[:, self.complex_inds].imag * 1j), axis=1
+        )
 
     def deserialize(self, parameters):
         """Convert serialized parameters to dictionary
         """
         n = 0
+        m = self.nparams
         d = {}
         for k, opt in self.to_opt.items():
             opt_ = opt.flatten()
@@ -95,6 +108,10 @@ class LinearTransform:
             flat_parms = np.zeros(self.slices[k], dtype=self.dtypes[k])
             flat_parms[~opt_] = self.frozen_parms[k]
             flat_parms[opt_] = parameters[n : n + n_p]
+            if self.complex[k]:
+                m_p = self.nimag[k]
+                flat_parms[opt_] += parameters[m : m + m_p] * 1j
+                m += m_p
             d[k] = flat_parms.reshape(self.shapes[k])
             n += n_p
         return d

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -138,10 +138,10 @@ class PySCFSlater:
         self.iscomplex = self.iscomplex or np.linalg.norm(self._kpts) > 1e-12
 
         # Define nelec
-        if isinstance(mf, scf.kuhf.KUHF):
+        if len(mf.mo_coeff[0][0].shape) == 2:
             # Then indices are (spin, kpt, basis, mo)
             self._nelec = [int(np.sum([o[k] for k in self.kinds])) for o in mf.mo_occ]
-        elif isinstance(mf, scf.khf.KRHF):
+        elif len(mf.mo_coeff[0][0].shape) == 1:
             # Then indices are (kpt, basis, mo)
             self._nelec = [
                 int(np.sum([mf.mo_occ[k] > t for k in self.kinds])) for t in (0.9, 1.1)

--- a/tests/integration/test_complex_linemin.py
+++ b/tests/integration/test_complex_linemin.py
@@ -1,0 +1,48 @@
+import numpy as np
+import os
+import pyqmc.recipes
+
+
+def run_scf(chkfile):
+    from pyscf.pbc import gto, scf
+    from pyscf.scf.addons import remove_linear_dep_
+
+    mol = gto.Cell(
+        atom="H 0 0 0; H 2 2 2",
+        a=np.eye(3) * 5,
+        basis="ccecpccpvdz",
+        ecp="ccecp",
+        unit="bohr",
+    )
+    mol.exp_to_discard = 0.1
+    mol.build()
+    mf = scf.KUKS(mol, kpts=mol.make_kpts([3, 3, 3]))
+    mf.chkfile = chkfile
+    mf = remove_linear_dep_(mf)
+
+    dm = np.asarray(mf.get_init_guess())
+    n = int(dm.shape[-1] / 2)
+    dm[0, :n, :n] = 0
+    dm[1, n:, n:] = 0
+    energy = mf.kernel(dm)
+
+
+def test():
+    chkfile = "hepbc.hdf5"
+    optfile = "linemin.hdf5"
+    run_scf(chkfile)
+    pyqmc.recipes.OPTIMIZE(
+        chkfile,
+        optfile,
+        nconfig=50,
+        S=np.diag([1, 1, 3]),
+        slater_kws={"optimize_orbitals": True},
+        linemin_kws={"max_iterations": 5},
+    )
+    assert os.path.isfile(optfile)
+    os.remove(chkfile)
+    os.remove(optfile)
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
Parameter derivatives (e.g. dp<H>) for complex p are separated into derivatives w.r.t. the real and imaginary parts. Implemented in LinearTransform by appending the imaginary parts to the parameter list (of real parts).

The test runs a few iterations of linemin on a periodic system with complex MO coeffs to make sure it runs without error. I checked a longer run of this test manually to ensure that the optimization looks reasonable, but don't have an idea for an "assert test" yet.

Slater init_pbc now checks shape of mf instead of type (RHF/UHF), so that recover_pyscf works for KUHF objects.