### PR TITLE
read_wf for complex wave functions

### DIFF
--- a/pyqmc/__init__.py
+++ b/pyqmc/__init__.py
@@ -261,7 +261,7 @@ read_wf(wf, "linemin.hdf5")
             for k in grp.keys():
                 wf.parameters[k] = np.array(grp[k])
 
-    wf.iscomplex = bool(sum(map(np.iscomplexobj, self.parameters.values())))
+    wf.iscomplex = bool(sum(map(np.iscomplexobj, wf.parameters.values())))
     if hasattr(wf, "_kpts"):
-        wf.iscomplex = wf.iscomplex or np.linalg.norm(self._kpts) > 1e-12
+        wf.iscomplex = wf.iscomplex or np.linalg.norm(wf._kpts) > 1e-12
     wf.dtype = complex if wf.iscomplex else float

--- a/pyqmc/__init__.py
+++ b/pyqmc/__init__.py
@@ -260,3 +260,8 @@ read_wf(wf, "linemin.hdf5")
             grp = hdf["wf"]
             for k in grp.keys():
                 wf.parameters[k] = np.array(grp[k])
+
+    wf.iscomplex = bool(sum(map(np.iscomplexobj, self.parameters.values())))
+    if hasattr(wf, "_kpts"):
+        wf.iscomplex = wf.iscomplex or np.linalg.norm(self._kpts) > 1e-12
+    wf.dtype = complex if wf.iscomplex else float

--- a/pyqmc/multiplywf.py
+++ b/pyqmc/multiplywf.py
@@ -47,6 +47,12 @@ class Parameters:
             for k2 in self.data[k1].keys():
                 yield k1 + k2
 
+    def values(self):
+        for i in range(self.wf_count):
+            k1 = "wf" + str(i + 1)
+            for k2 in self.data[k1].keys():
+                yield self.data[k1][k2]
+
 
 class MultiplyWF:
     """


### PR DESCRIPTION
Wave functions have attributes `iscomplex` and `dtype`, which are not stored in the parameters dictionary. In order for recipes to work for complex wave functions, read_wf needs to set these attributes depending on the parameters loaded in from wf_file.

This PR also adds the function `values()` to the multiplywf.Parameters class