### PR TITLE
Fix complex derivatives in orthogonal optimization

### DIFF
--- a/doc/source/methods.rst
+++ b/doc/source/methods.rst
@@ -2,17 +2,17 @@ Monte Carlo methods
 =================================
 
 
-----------------------
+-----------------------
 Variational Monte Carlo
-----------------------
+-----------------------
 
 .. automodule:: pyqmc.mc
    :members:
 
 
-----------------------
+--------------------------
 Wave function optimization
-----------------------
+--------------------------
 
 .. automodule:: pyqmc.linemin
    :members:
@@ -25,9 +25,9 @@ Diffusion Monte Carlo
    :members:
 
 
-----------------------
+-----------------------
 Orthogonal optimization
-----------------------
+-----------------------
 
-.. automodule:: pyqmc.optimize_orthogonal
+.. automodule:: pyqmc.optimize_ortho
    :members:

--- a/doc/source/wavefunction.rst
+++ b/doc/source/wavefunction.rst
@@ -42,7 +42,7 @@ Returns d_p \Psi/\Psi as a dictionary of numpy arrays, which correspond to the p
 Slater determinant
 ----------------------
 
-.. automodule:: pyqmc.slateruhf
+.. automodule:: pyqmc.slater
    :members:
    
 

--- a/pyqmc/linemin.py
+++ b/pyqmc/linemin.py
@@ -113,31 +113,31 @@ def line_minimization(
 
     Args:
 
-      wf: initial wave function
+      :wf: initial wave function
 
-      coords: initial configurations
+      :coords: initial configurations
 
-      pgrad_acc: A PGradAccumulator-like object
+      :pgrad_acc: A PGradAccumulator-like object
 
-      steprange: How far to search in the line minimization
+      :steprange: How far to search in the line minimization
 
-      warmup: number of steps to use for vmc warmup
+      :warmup: number of steps to use for vmc warmup
 
-      max_iterations: (maximum) number of steps in the gradient descent
+      :max_iterations: (maximum) number of steps in the gradient descent
 
-      vmcoptions: a dictionary of options for the vmc method
+      :vmcoptions: a dictionary of options for the vmc method
 
-      lmoptions: a dictionary of options for the lm method
+      :lmoptions: a dictionary of options for the lm method
 
-      update: A function that generates a parameter change 
+      :update: A function that generates a parameter change 
 
-      update_kws: Any keywords 
+      :update_kws: Any keywords 
 
-      npts: number of points to fit to in each line minimization
+      :npts: number of points to fit to in each line minimization
 
     Returns:
 
-      wf: optimized wave function
+      :wf: optimized wave function
 
 
     """
@@ -265,14 +265,16 @@ def correlated_compute(wf, configs, params, pgrad_acc):
     Evaluates accumulator on the same set of configs for correlated sampling of different wave function parameters
 
     Args:
-        wf: wave function object
-        configs: (nconf, nelec, 3) array
-        params: (nsteps, nparams) array 
+        :wf: wave function object
+        :configs: (nconf, nelec, 3) array
+        :params: (nsteps, nparams) array 
             list of arrays of parameters (serialized) at each step
-        pgrad_acc: PGradAccumulator 
+
+        :pgrad_acc: PGradAccumulator 
 
     Returns:
-        data: a single dict with indices [parameter, values]
+        :data: a single dict with indices [parameter, values]
+
     """
 
     import copy

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -25,17 +25,17 @@ def collect_overlap_data(wfs, configs, pgrad):
     r""" Collect the averages assuming that 
     configs are distributed according to 
     
-    .. math:: \rho \propto sum_i |\Psi_i|^2
+    .. math:: \rho \propto \sum_i |\Psi_i|^2
 
     The keys 'overlap' and 'overlap_gradient' are
 
-        `overlap` : 
+    `overlap` : 
 
-    .. math:: \left\langle \frac{\Psi_i^* \Psi_j}{\rho} \right\rangle
+    .. math:: \langle \Psi_f | \Psi_i \rangle = \left\langle \frac{\Psi_i^* \Psi_j}{\rho} \right\rangle_{\rho}
 
     `overlap_gradient`:
 
-    .. math:: \left\langle \frac{\partial_{im} \Psi_i^* \Psi_j}{\rho} \right\rangle
+    .. math:: \partial_m \langle \Psi_f | \Psi_i \rangle = \left\langle \frac{\partial_{fm} \Psi_i^* \Psi_j}{\rho} \right\rangle_{\rho}
 
     """
     phase, log_vals = [np.array(x) for x in zip(*[wf.value() for wf in wfs])]
@@ -84,8 +84,8 @@ def construct_rho_gradient(grads, log_values):
 
 
 def sample_overlap_worker(wfs, configs, pgrad, nsteps, tstep=0.5):
-    """ Run nstep Metropolis steps to sample a distribution proportional to 
-    sum_i |psi_i|^2, where psi_i = wfs[i]
+    r""" Run nstep Metropolis steps to sample a distribution proportional to 
+    :math:`\sum_i |\Psi_i|^2`, where :math:`\Psi_i` = wfs[i]
     """
     nconf, nelec, _ = configs.configs.shape
     for wf in wfs:
@@ -234,7 +234,7 @@ def correlated_sample(wfs, configs, parameters, pgrad):
 
     The ratio can be computed as 
 
-    .. math:: \frac{|\Psi|^2}{\rho} = \frac{1}{\sum_i e^{\alpha_i - \alpha} 
+    .. math:: \frac{|\Psi|^2}{\rho} = \frac{1}{\sum_i e^{2(\alpha_i - \alpha}) }
 
     Where we write 
 
@@ -325,7 +325,7 @@ def dist_correlated_sample(wfs, configs, *args, client, npartitions=None, **kwar
 
 def renormalize(wfs, N):
     """
-    Normalize the last wave function, given a current value of the normalization. Assumes that we want N to be 0.5
+    Normalizes the last wave function, given a current value of the normalization. Assumes that we want N to be 0.5
 
     .. math:: 
     
@@ -402,15 +402,15 @@ def optimize_orthogonal(
     r"""
     Minimize 
 
-    .. math:: f(p_f) = E_f + \sum_i \lambda_{i=0}^{f-1} (S_{fi} - S_{fi}^*)^2 
+    .. math:: f(p_f) = E_f + \sum_i \lambda_{i=0}^{f-1} |S_{fi} - S_{fi}^*|^2 
 
     Where 
 
-    .. math:: N_i = \langle \Psi_i | \Psi_j \rangle
+    .. math:: N_i = \langle \Psi_i | \Psi_i \rangle
 
-    .. math:: S_{fi} = \frac{\langle \Psi_f | \Psi_j \rangle}{\sqrt{N_f N_i}}
+    .. math:: S_{fi} = \frac{\langle \Psi_f | \Psi_i \rangle}{\sqrt{N_f N_i}}
 
-    The *'d and lambda values are respectively targets and forcings. f is the final wave function in the wave function array.
+    The \*'d and lambda values are respectively targets and forcings. f is the final wave function in the wave function array.
     We only optimize the parameters of the final wave function, so all 'p' values here represent a parameter in the final wave function. 
 
     **Important arguments**
@@ -441,9 +441,9 @@ def optimize_orthogonal(
 
     .. math:: \partial_p N_f = 2 Re \langle \partial_p \Psi_f | \Psi_f \rangle
 
-    .. math::  \langle \partial_p \Psi_f | \Psi_f \rangle = \int{ \frac{ \Psi_f\partial_p \Psi_f^*}{\rho} \frac{\rho}{\int \rho} } 
+    .. math::  \langle \partial_p \Psi_f | \Psi_i \rangle = \int{ \frac{ \Psi_i\partial_p \Psi_f^*}{\rho} \frac{\rho}{\int \rho} } 
 
-    .. math:: \partial_p S_{fi} = \frac{\langle \partial_p \Psi_f | \Psi_j \rangle}{\sqrt{N_f N_i}} - \frac{\langle \Psi_f | \Psi_j \rangle}{\sqrt{N_f N_i}} \frac{\partial_p N_f}{N_f} 
+    .. math:: \partial_p S_{fi} = \frac{\langle \partial_p \Psi_f | \Psi_i \rangle}{\sqrt{N_f N_i}} - \frac{\langle \Psi_f | \Psi_i \rangle}{2\sqrt{N_f N_i}} \frac{\partial_p N_f}{N_f} 
 
     In this implementation, we set 
 
@@ -485,8 +485,11 @@ def optimize_orthogonal(
         forcing = np.ones(len(wfs) - 1)
     Starget = np.asarray(Starget)
     forcing = np.asarray(forcing)
-    if len(forcing) != len(wfs)-1:
-        raise AttributeError("forcing should be an array of length equal to the wfs minus 1: "+str(len(forcing)))
+    if len(forcing) != len(wfs) - 1:
+        raise AttributeError(
+            "forcing should be an array of length equal to the wfs minus 1: "
+            + str(len(forcing))
+        )
     attr = dict(
         tstep=tstep,
         max_iterations=max_iterations,

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -573,12 +573,13 @@ def optimize_orthogonal(
             overlap_derivatives[i + 1] = deriv_data["S_derivative"][0, :]
         print("normalization", normalization)
 
-        ovlp_phase = overlaps / np.abs(overlaps)
+        delta = overlaps - Starget
+        delta_phase = delta / np.abs(delta)
         overlap_derivative = np.sum(
             2.0
             * forcing
-            * (np.abs(overlaps) - Starget)[:, np.newaxis]
-            * np.real(overlap_derivatives / ovlp_phase),
+            * np.abs(delta)[:, np.newaxis]
+            * np.real(overlap_derivatives / delta_phase),
             axis=0,
         )
 

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -575,12 +575,10 @@ def optimize_orthogonal(
 
         delta = overlaps - Starget
         delta_phase = delta / np.abs(delta)
-        overlap_derivative = np.sum(
-            2.0
-            * forcing
-            * np.abs(delta)[:, np.newaxis]
-            * np.real(overlap_derivatives / delta_phase),
-            axis=0,
+        overlap_derivative = np.einsum(
+            "j,jk->k",
+            2.0 * forcing * np.abs(delta),
+            np.real(overlap_derivatives / delta_phase[:, np.newaxis]),
         )
 
         total_derivative = energy_derivative + overlap_derivative

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -363,7 +363,9 @@ def evaluate(return_data, warmup):
     S_derivative = avg_data["overlap_gradient"] / Nij[-1, :, np.newaxis] - np.einsum(
         "j,m->jm", 0.5 * avg_data["overlap"][-1, :] / Nij[-1, :], N_derivative / N[-1]
     )
-    energy_derivative = 2.0 * (avg_data["dpH"] - avg_data["total"] * avg_data["dppsi"])
+    energy_derivative = 2.0 * np.real(
+        avg_data["dpH"] - avg_data["total"] * avg_data["dppsi"]
+    )
     dp = avg_data["dppsi"]
     condition = np.real(avg_data["dpidpj"] - np.einsum("i,j->ij", dp, dp))
 

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -573,8 +573,12 @@ def optimize_orthogonal(
             overlap_derivatives[i + 1] = deriv_data["S_derivative"][0, :]
         print("normalization", normalization)
 
+        ovlp_phase = overlaps / np.abs(overlaps)
         overlap_derivative = np.sum(
-            2.0 * (forcing * (overlaps - Starget))[:, np.newaxis] * overlap_derivatives,
+            2.0
+            * forcing
+            * (np.abs(overlaps) - Starget)[:, np.newaxis]
+            * np.real(overlap_derivatives / ovlp_phase),
             axis=0,
         )
 


### PR DESCRIPTION
The energy derivatives are made real, as they are in linemin.

The phase of the overlap is not important - the total_derivative is now defined only using the derivative of the magnitude of the overlaps.

Making these derivatives real improves the convergence of the complex-parameter molecule.