### PR TITLE
update aovals with mask for computing pgradient

### DIFF
--- a/pyqmc/multislater.py
+++ b/pyqmc/multislater.py
@@ -165,14 +165,14 @@ class MultiSlater:
             mask = [True] * epos.configs.shape[0]
         eeff = e - s * self._nelec[0]
         ao = np.real_if_close(
-            self._mol.eval_gto(self.pbc_str + "GTOval_sph", epos.configs), tol=1e4
+            self._mol.eval_gto(self.pbc_str + "GTOval_sph", epos.configs[mask]), tol=1e4
         )
-        self._aovals[:, e, :] = ao
+        self._aovals[mask, e, :] = ao
         mo = ao.dot(self.parameters[self._coefflookup[s]])
 
         mo_vals = mo[:, self._det_occup[s]]
         det_ratio, self._inverse[s][mask, :, :, :] = sherman_morrison_ms(
-            eeff, self._inverse[s][mask, :, :, :], mo_vals[mask, :]
+            eeff, self._inverse[s][mask, :, :, :], mo_vals
         )
 
         self._updateval(det_ratio, s, mask)

--- a/pyqmc/multislaterpbc.py
+++ b/pyqmc/multislaterpbc.py
@@ -142,11 +142,11 @@ class MultiSlaterPBC:
         if mask is None:
             mask = [True] * epos.configs.shape[0]
         eeff = e - s * self._nelec[0]
-        aos = self.evaluate_orbitals(epos)
-        self._aovals[:, :, e, :] = np.asarray(aos)
+        aos = self.evaluate_orbitals(epos, mask=mask)
+        self._aovals[:, mask, e, :] = np.asarray(aos)
         mo = self.evaluate_mos(aos, s)
         ratio, self._inverse[s][mask] = sherman_morrison_ms(
-            eeff, self._inverse[s][mask], mo[mask, :]
+            eeff, self._inverse[s][mask], mo
         )
         self._updateval(ratio, s, mask)
 

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -218,11 +218,11 @@ class PySCFSlater:
         if mask is None:
             mask = [True] * epos.configs.shape[0]
         eeff = e - s * self._nelec[0]
-        aos = self.evaluate_orbitals(epos)
-        self._aovals[:, :, e, :] = np.asarray(aos)  # (kpt, config, ao)
-        mo = self.evaluate_mos(aos, s).reshape(len(mask), -1)
+        aos = self.evaluate_orbitals(epos, mask=mask)
+        self._aovals[:, mask, e, :] = np.asarray(aos)  # (kpt, config, ao)
+        mo = self.evaluate_mos(aos, s)
         ratio, self._inverse[s][mask, :, :] = sherman_morrison_row(
-            eeff, self._inverse[s][mask, :, :], mo[mask, :]
+            eeff, self._inverse[s][mask, :, :], mo
         )
         self._updateval(ratio, s, mask)
 

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -3,13 +3,11 @@ from pyqmc import pbc
 
 
 def sherman_morrison_row(e, inv, vec):
-    ratio = np.einsum("ij,ij->i", vec, inv[:, :, e])
     tmp = np.einsum("ek,ekj->ej", vec, inv)
-    invnew = (
-        inv
-        - np.einsum("ki,kj->kij", inv[:, :, e], tmp) / ratio[:, np.newaxis, np.newaxis]
-    )
-    invnew[:, :, e] = inv[:, :, e] / ratio[:, np.newaxis]
+    ratio = tmp[:, e]
+    inv_ratio = inv[:, :, e] / ratio[:, np.newaxis]
+    invnew = inv - np.einsum("ki,kj->kij", inv_ratio, tmp)
+    invnew[:, :, e] = inv_ratio
     return ratio, invnew
 
 

--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -25,6 +25,7 @@ def test_updateinternals(wf, configs):
     tuple which 
 
     """
+    from pyqmc import vmc
 
     nconf, ne, ndim = configs.configs.shape
     delta = 1e-2
@@ -52,10 +53,17 @@ def test_updateinternals(wf, configs):
         )
         val1 = recompute
 
+    # Test mask and pgrad
+    _, configs = vmc(wf, configs, nblocks=1, nsteps_per_block=1, tstep=2)
+    pgradupdate = wf.pgradient()
+    wf.recompute(configs)
+    pgrad = wf.pgradient()
+    pgdict = {k: np.max(np.abs(pgu - pgrad[k])) for k, pgu in pgradupdate.items()}
     return {
         "updatevstest": np.max(np.abs(updatevstest)),
         "recomputevstest": np.max(np.abs(recomputevstest)),
         "recomputevsupdate": np.max(np.abs(recomputevsupdate)),
+        **pgdict,
     }
 
 


### PR DESCRIPTION
The mask wasn't used for updating aovals in the slater objects. This PR changes updateinternals in the Slater objects to update aovals using the mask, and only evaluate orbitals where updates are needed. It also adds a test in pyqmc.testwf.test_updateinternals() that the previous version fails.