### PR TITLE
use reference determinant in multislater value()

### DIFF
--- a/pyqmc/multislater.py
+++ b/pyqmc/multislater.py
@@ -179,22 +179,20 @@ class MultiSlater:
 
     def value(self):
         """Return logarithm of the wave function as noted in recompute()"""
-        wf_val = 0
-        wf_sign = 0
+        updets = self._dets[0][:, :, self._det_map[0]]
+        dndets = self._dets[1][:, :, self._det_map[1]]
+        upref = np.amax(self._dets[0][1])
+        dnref = np.amax(self._dets[1][1])
+        phases = updets[0] * dndets[0]
+        logvals = updets[1] - upref + dndets[1] - dnref
+
         wf_val = np.einsum(
-            "d,di->i",
-            self.parameters["det_coeff"],
-            self._dets[0][0, :, self._det_map[0]]
-            * self._dets[1][0, :, self._det_map[1]]
-            * np.exp(
-                self._dets[0][1, :, self._det_map[0]]
-                + self._dets[1][1, :, self._det_map[1]]
-            ),
+            "d,di->i", self.parameters["det_coeff"], phases * np.exp(logvals)
         )
 
         wf_sign = self.get_phase(wf_val)
-        wf_val = np.log(np.abs(wf_val))
-        return wf_sign, wf_val
+        wf_logval = np.log(np.abs(wf_val)) + upref + dnref
+        return wf_sign, wf_logval
 
     def _updateval(self, ratio, s, mask):
         self._dets[s][0, mask, :] *= self.get_phase(ratio)

--- a/pyqmc/multislater.py
+++ b/pyqmc/multislater.py
@@ -187,7 +187,7 @@ class MultiSlater:
         logvals = updets[1] - upref + dndets[1] - dnref
 
         wf_val = np.einsum(
-            "d,di->i", self.parameters["det_coeff"], phases * np.exp(logvals)
+            "d,id->i", self.parameters["det_coeff"], phases * np.exp(logvals)
         )
 
         wf_sign = self.get_phase(wf_val)

--- a/pyqmc/multislaterpbc.py
+++ b/pyqmc/multislaterpbc.py
@@ -1,6 +1,6 @@
 import numpy as np
 from pyqmc.multislater import sherman_morrison_ms
-from pyqmc.slater import get_kinds
+from pyqmc.slater import get_k_indices
 from pyqmc.supercell import get_supercell_kpts
 from pyqmc import pbc, slater
 
@@ -41,7 +41,7 @@ class MultiSlaterPBC:
             twist = np.zeros(3)
         else:
             twist = np.dot(np.linalg.inv(supercell.a), np.mod(twist, 1.0)) * 2 * np.pi
-        self.kinds = get_kinds(self._mol, mf, get_supercell_kpts(supercell) + twist)
+        self.kinds = get_k_indices(self._mol, mf, get_supercell_kpts(supercell) + twist)
         self._kpts = mf.kpts[self.kinds]
         assert len(self.kinds) == len(self._kpts), (self._kpts, mf.kpts)
         self.nk = len(self._kpts)


### PR DESCRIPTION
fixes issue #236 

Computes determinant values as a ratio with a reference determinant instead of adding together "raw" determinant values.