### PR TITLE
fix bug parallelizing pbcs

### DIFF
--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -11,21 +11,8 @@ class EnergyAccumulator:
         self.mol = mol
         self.threshold = threshold
         if hasattr(mol, "a"):
-            self.ewald = Ewald(mol, **kwargs)
-
-            def compute_energy(mol, configs, wf, threshold):
-                ee, ei, ii = self.ewald.energy(configs)
-                ecp_val = energy.get_ecp(mol, configs, wf, threshold)
-                ke = energy.kinetic(configs, wf)
-                return {
-                    "ke": ke,
-                    "ee": ee,
-                    "ei": ei,
-                    "ecp": ecp_val,
-                    "total": ke + ee + ei + ecp_val + ii,
-                }
-
-            self.compute_energy = compute_energy
+            ewald = Ewald(mol, **kwargs)
+            self.compute_energy = ewald.compute_total_energy
         else:
             self.compute_energy = energy.energy
 

--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pyqmc
 from scipy.special import erfc
+import pyqmc.energy
 
 
 class Ewald:
@@ -385,3 +386,15 @@ class Ewald:
         Vtest[:, -1] += 2 * ei_recip_separated
 
         return Vtest
+
+    def compute_total_energy(self, mol, configs, wf, threshold):
+        ee, ei, ii = self.energy(configs)
+        ecp_val = pyqmc.energy.get_ecp(mol, configs, wf, threshold)
+        ke = pyqmc.energy.kinetic(configs, wf)
+        return {
+            "ke": ke,
+            "ee": ee,
+            "ei": ei,
+            "ecp": ecp_val,
+            "total": ke + ee + ei + ecp_val + ii,
+        }


### PR DESCRIPTION
ProcessPoolExecutor failed with pbcs because of defining `compute_energy` as a nested function in EnergyAccumulator. This PR defines the function in the Ewald class, so that is has access to the ewald object's energy function and the same inputs as the original energy function.