### PR TITLE
speed up ewald reciprocal electron

### DIFF
--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -363,6 +363,7 @@ class Ewald:
         Returns: 
             (nelec,) energies
         """
+        raise NotImplementedError("ewalde_separated is currently not computed anywhere")
         nelec = configs.configs.shape[1]
         return self.e_single(nelec) + self.ewalde_separated
 

--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -135,6 +135,7 @@ class Ewald:
         bigweight = gweight > 1e-10
         self.gpoints = gpoints[bigweight]
         self.gweight = gweight[bigweight]
+        print("no. ewald gpoints", len(self.gpoints))
 
         self.set_ewald_constants(cellvolume)
 
@@ -286,21 +287,39 @@ class Ewald:
                 ee_real_separated[:, j] += val
             ee_real_separated /= 2
 
+        ee_recip, ei_recip = self.reciprocal_space_electron(configs.configs)
+        ee = ee_real_separated.sum(axis=1) + ee_recip
+        ei = ei_real_separated.sum(axis=1) + ei_recip
+        return ee, ei
+
+    def reciprocal_space_electron(self, configs):
         # Reciprocal space electron-electron part
-        e_GdotR = np.dot(configs.configs, self.gpoints.T)
-        e_expGdotR = np.exp(1j * e_GdotR)
-        sum_e_exp = np.sum(e_expGdotR, axis=1, keepdims=True)
-        coscos_sinsin = np.real(sum_e_exp.conj() * e_expGdotR)
-        ### Don't know why we subtract 0.5 for "separated"
-        ee_recip_separated = np.dot(coscos_sinsin - 0.5, self.gweight)
+        e_GdotR = np.einsum("hik,jk->hij", configs, self.gpoints)
+        sum_e_sin = np.sin(e_GdotR).sum(axis=1)
+        sum_e_cos = np.cos(e_GdotR).sum(axis=1)
+        ee_recip = np.dot(sum_e_sin ** 2 + sum_e_cos ** 2, self.gweight)
+        ## Reciprocal space electron-ion part
+        coscos_sinsin = -self.ion_exp.real * sum_e_cos + self.ion_exp.imag * sum_e_sin
+        ei_recip = 2 * np.dot(coscos_sinsin, self.gweight)
+        return ee_recip, ei_recip
 
-        # Reciprocal space electron-ion part
-        coscos_sinsin = np.real(-self.ion_exp.conj() * e_expGdotR)
-        ei_recip_separated = np.dot(coscos_sinsin, self.gweight)
+    def reciprocal_space_electron_separated(self, configs):
+        # Reciprocal space electron-electron part
+        e_GdotR = np.einsum("hik,jk->hij", configs, self.gpoints)
+        e_sin = np.sin(e_GdotR)
+        e_cos = np.cos(e_GdotR)
+        sinsin = e_sin.sum(axis=1, keepdims=True) * e_sin
+        coscos = e_cos.sum(axis=1, keepdims=True) * e_cos
+        ee_recip = np.dot(coscos + sinsin - 0.5, self.gweight)
+        ## Reciprocal space electron-ion part
+        coscos_sinsin = -self.ion_exp.real * e_cos + self.ion_exp.imag * e_sin
+        ei_recip = np.dot(coscos_sinsin, self.gweight)
+        return ee_recip, ei_recip
 
+    def save_separated(ee_recip, ei_recip, ee_real, ei_real):
         # Combine parts
-        self.ei_separated = ei_real_separated + 2 * ei_recip_separated
-        self.ee_separated = ee_real_separated + 1 * ee_recip_separated
+        self.ei_separated = ei_real + 2 * ei_recip
+        self.ee_separated = ee_real + 1 * ee_recip
         self.ewalde_separated = self.ei_separated + self.ee_separated
         nelec = ee_recip_separated.shape[1]
         ### Add back the 0.5 that was subtracted earlier

--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -316,7 +316,7 @@ class Ewald:
         ei_recip = np.dot(coscos_sinsin, self.gweight)
         return ee_recip, ei_recip
 
-    def save_separated(ee_recip, ei_recip, ee_real, ei_real):
+    def save_separated(self, ee_recip, ei_recip, ee_real, ei_real):
         # Combine parts
         self.ei_separated = ei_real + 2 * ei_recip
         self.ee_separated = ee_real + 1 * ee_recip

--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -321,7 +321,7 @@ class Ewald:
         self.ei_separated = ei_real + 2 * ei_recip
         self.ee_separated = ee_real + 1 * ee_recip
         self.ewalde_separated = self.ei_separated + self.ee_separated
-        nelec = ee_recip_separated.shape[1]
+        nelec = ee_recip.shape[1]
         ### Add back the 0.5 that was subtracted earlier
         ee = self.ee_separated.sum(axis=1) + nelec / 2 * self.gweight.sum()
         ei = self.ei_separated.sum(axis=1)

--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -135,7 +135,6 @@ class Ewald:
         bigweight = gweight > 1e-10
         self.gpoints = gpoints[bigweight]
         self.gweight = gweight[bigweight]
-        print("no. ewald gpoints", len(self.gpoints))
 
         self.set_ewald_constants(cellvolume)
 


### PR DESCRIPTION
- reciprocal electron (ee and ei) are separated out from ewald_electron
- the implementation that stores separate electrons contributions was replaced by a function that does not compute them separately (the separated function is still in the class but not used)
- dot + transpose is replaced with einsum
- complex exp is replaced with sin and cos
- energy_separated now raises a NotImplementedError because we don't compute the separated values