### PR TITLE
clean up testwf and func3d test output formats

### DIFF
--- a/pyqmc/func3d.py
+++ b/pyqmc/func3d.py
@@ -427,9 +427,8 @@ def test_func3d_gradient(bf, delta=1e-5):
         pos[..., d] -= 2 * delta
         minuval = bf.value(pos, np.linalg.norm(pos, axis=-1))
         numeric[..., d] = (plusval - minuval) / (2 * delta)
-    meanerror = np.mean(np.abs(grad - numeric))
-    normerror = np.linalg.norm(grad - numeric)
-    return (meanerror, normerror)
+    maxerror = np.max(np.abs(grad - numeric))
+    return maxerror
 
 
 def test_func3d_laplacian(bf, delta=1e-5):
@@ -446,9 +445,8 @@ def test_func3d_laplacian(bf, delta=1e-5):
         r = np.linalg.norm(pos, axis=-1)
         minuval = bf.gradient(pos, r)[..., d]
         numeric[..., d] = (plusval - minuval) / (2 * delta)
-    meanerror = np.mean(np.abs(lap - numeric))
-    normerror = np.linalg.norm(lap - numeric)
-    return (meanerror, normerror)
+    maxerror = np.max(np.abs(lap - numeric))
+    return maxerror
 
 
 def test_func3d_gradient_laplacian(bf):
@@ -457,9 +455,9 @@ def test_func3d_gradient_laplacian(bf):
     grad = bf.gradient(rvec, r)
     lap = bf.laplacian(rvec, r)
     andgrad, andlap = bf.gradient_laplacian(rvec, r)
-    graderr = np.linalg.norm((grad - andgrad))
-    laperr = np.linalg.norm((lap - andlap))
-    return (graderr, laperr)
+    graderr = np.amax(np.abs(grad - andgrad))
+    laperr = np.amax(np.abs(lap - andlap))
+    return {"grad": graderr, "lap": laperr}
 
 
 def test_func3d_pgradient(bf, delta=1e-5):
@@ -467,7 +465,7 @@ def test_func3d_pgradient(bf, delta=1e-5):
     r = np.linalg.norm(rvec, axis=-1)
     pgrad = bf.pgradient(rvec, r)
     numeric = {k: np.zeros(v.shape) for k, v in pgrad.items()}
-    meanerror = {k: np.zeros(v.shape) for k, v in pgrad.items()}
+    maxerror = {k: np.zeros(v.shape) for k, v in pgrad.items()}
     normerror = {k: np.zeros(v.shape) for k, v in pgrad.items()}
     for k in pgrad.keys():
         bf.parameters[k] += delta
@@ -476,8 +474,7 @@ def test_func3d_pgradient(bf, delta=1e-5):
         minuval = bf.value(rvec, r)
         bf.parameters[k] += delta
         numeric[k] = (plusval - minuval) / (2 * delta)
-        meanerror[k] = np.mean(np.abs(pgrad[k] - numeric[k]))
-        normerror[k] = np.linalg.norm(pgrad[k] - numeric[k])
-        if meanerror[k] > 1e-5:
+        maxerror[k] = np.max(np.abs(pgrad[k] - numeric[k]))
+        if maxerror[k] > 1e-5:
             print(k, "\n", pgrad[k] - numeric[k])
-    return (meanerror, normerror)
+    return maxerror

--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -100,11 +100,7 @@ def test_wf_gradient(wf, configs, delta=1e-5):
             minuval = wf.testvalue(e, epos)
             numeric[:, e, d] = (plusval - minuval) / (2 * delta)
     maxerror = np.amax(np.abs(grad - numeric))
-    normerror = np.mean(np.abs(grad - numeric))
-
-    # print('maxerror', maxerror, np.log10(maxerror))
-    # print('normerror', normerror, np.log10(normerror))
-    return (maxerror, normerror)
+    return maxerror
 
 
 def test_wf_pgradient(wf, configs, delta=1e-5):
@@ -132,7 +128,7 @@ def test_wf_pgradient(wf, configs, delta=1e-5):
             wf.parameters[k] = flt.reshape(wf.parameters[k].shape)
 
         pgerr = np.abs(gradient[k].reshape((-1, nparms)) - numgrad)
-        error[k] = (np.amax(pgerr), np.mean(pgerr))
+        error[k] = np.amax(pgerr)
     if len(error) == 0:
         return (0, 0)
     return error[max(error)]  # Return maximum coefficient error
@@ -176,10 +172,7 @@ def test_wf_laplacian(wf, configs, delta=1e-5):
             numeric[:, e] += np.real(plusgrad - minugrad) / (2 * delta)
 
     maxerror = np.amax(np.abs(lap - numeric))
-    normerror = np.mean(np.abs((lap - numeric) / numeric))
-    # print('maxerror', maxerror, np.log10(maxerror))
-    # print('normerror', normerror, np.log10(normerror))
-    return (maxerror, normerror)
+    return maxerror
 
 
 def test_wf_gradient_laplacian(wf, configs):
@@ -204,17 +197,12 @@ def test_wf_gradient_laplacian(wf, configs):
         tt1 = time.time()
         tsep += ts1 - ts0
         ttog += tt1 - tt0
-        rmae_grad = np.mean(np.abs((andgrad - grad) / grad))
-        rmae_lap = np.mean(np.abs((andlap - lap) / lap))
-        norm_grad = np.linalg.norm((andgrad - grad) / grad)
-        norm_lap = np.linalg.norm((andlap - lap) / lap)
+        rel_grad = np.abs((andgrad - grad) / grad)
+        rel_lap = np.abs((andlap - lap) / lap)
+        rmax_grad = np.max(rel_grad)
+        rmax_lap = np.max(rel_lap)
 
     print("separate", tsep)
     print("together", ttog)
 
-    d = []
-    d.append({"error": rmae_grad, "deriv": "grad", "type": "mae"})
-    d.append({"error": rmae_lap, "deriv": "lap", "type": "mae"})
-    d.append({"error": norm_grad, "deriv": "grad", "type": "norm"})
-    d.append({"error": norm_lap, "deriv": "lap", "type": "norm"})
-    return d
+    return {"grad": rmax_grad, "lap": rmax_lap}

--- a/tests/integration/test_multislater.py
+++ b/tests/integration/test_multislater.py
@@ -40,9 +40,9 @@ def test():
 
         for k, item in testwf.test_updateinternals(wf, epos).items():
             assert item < epsilon
-        assert testwf.test_wf_gradient(wf, epos, delta=delta)[0] < epsilon
-        assert testwf.test_wf_laplacian(wf, epos, delta=delta)[0] < epsilon
-        assert testwf.test_wf_pgradient(wf, epos, delta=delta)[0] < epsilon
+        assert testwf.test_wf_gradient(wf, epos, delta=delta) < epsilon
+        assert testwf.test_wf_laplacian(wf, epos, delta=delta) < epsilon
+        assert testwf.test_wf_pgradient(wf, epos, delta=delta) < epsilon
 
         # Test same number of elecs
         mc = mcscf.CASCI(mf, ncas=4, nelecas=(1, 1))
@@ -54,9 +54,9 @@ def test():
 
         for k, item in testwf.test_updateinternals(wf, epos).items():
             assert item < epsilon
-        assert testwf.test_wf_gradient(wf, epos, delta=delta)[0] < epsilon
-        assert testwf.test_wf_laplacian(wf, epos, delta=delta)[0] < epsilon
-        assert testwf.test_wf_pgradient(wf, epos, delta=delta)[0] < epsilon
+        assert testwf.test_wf_gradient(wf, epos, delta=delta) < epsilon
+        assert testwf.test_wf_laplacian(wf, epos, delta=delta) < epsilon
+        assert testwf.test_wf_pgradient(wf, epos, delta=delta) < epsilon
 
         # Test different number of elecs
         mc = mcscf.CASCI(mf, ncas=4, nelecas=(2, 0))
@@ -68,9 +68,9 @@ def test():
 
         for k, item in testwf.test_updateinternals(wf, epos).items():
             assert item < epsilon
-        assert testwf.test_wf_gradient(wf, epos, delta=delta)[0] < epsilon
-        assert testwf.test_wf_laplacian(wf, epos, delta=delta)[0] < epsilon
-        assert testwf.test_wf_pgradient(wf, epos, delta=delta)[0] < epsilon
+        assert testwf.test_wf_gradient(wf, epos, delta=delta) < epsilon
+        assert testwf.test_wf_laplacian(wf, epos, delta=delta) < epsilon
+        assert testwf.test_wf_pgradient(wf, epos, delta=delta) < epsilon
 
         # Quick VMC test
         nconf = 1000

--- a/tests/unit/test_derivatives.py
+++ b/tests/unit/test_derivatives.py
@@ -59,7 +59,7 @@ def test_wfs():
         ):
             err = []
             for delta in [1e-4, 1e-5, 1e-6, 1e-7, 1e-8]:
-                err.append(func(wf, epos, delta)[0])
+                err.append(func(wf, epos, delta))
             print(type(wf), fname, min(err))
             assert min(err) < epsilon, "epsilon {0}".format(epsilon)
 
@@ -121,7 +121,7 @@ def test_pbc_wfs():
         ):
             err = []
             for delta in [1e-4, 1e-5, 1e-6, 1e-7, 1e-8]:
-                err.append(func(wf, epos, delta)[0])
+                err.append(func(wf, epos, delta))
             print(type(wf), fname, min(err))
             assert min(err) < epsilon
 
@@ -155,16 +155,16 @@ def test_func3d():
     epsilon = 1e-5
 
     for name, func in test_functions.items():
-        grad = test_func3d_gradient(func, delta=delta)[0]
-        lap = test_func3d_laplacian(func, delta=delta)[0]
-        andg, andl = test_func3d_gradient_laplacian(func)
-        pgrad = test_func3d_pgradient(func, delta=1e-9)[0]
-        print(name, grad, lap, "both:", andg, andl)
+        grad = test_func3d_gradient(func, delta=delta)
+        lap = test_func3d_laplacian(func, delta=delta)
+        gl = test_func3d_gradient_laplacian(func)
+        pgrad = test_func3d_pgradient(func, delta=1e-9)
+        print(name, grad, lap, "both:", gl["grad"], gl["lap"])
         print(name, pgrad)
         assert grad < epsilon
         assert lap < epsilon
-        assert andg < epsilon
-        assert andl < epsilon, andl
+        assert gl["grad"] < epsilon
+        assert gl["lap"] < epsilon
         for k, v in pgrad.items():
             assert v < epsilon, (name, k, v)
 


### PR DESCRIPTION
Addresses issue #259 to make testwf output formats more consistent, and remove the quantities we are not using. Functions test_wf_gradient, test_wf_laplacian, and test_wf_pgradient (and the corresponding func3d functions) return just the max absolute error. Functions test_updateinternals, test_wf_gradient_laplacian, and test_func3d_gradient_laplacian return a dict of max abs error for the different quantities.