### PR TITLE
return *Electron object from *Configs.electron() function

### DIFF
--- a/pyqmc/coord.py
+++ b/pyqmc/coord.py
@@ -16,7 +16,7 @@ class OpenConfigs:
         self.dist = RawDistance()
 
     def electron(self, e):
-        return OpenConfigs(self.configs[:, e])
+        return OpenElectron(self.configs[:, e], self.dist)
 
     def mask(self, mask):
         return OpenConfigs(self.configs[mask])
@@ -126,7 +126,9 @@ class PeriodicConfigs:
         self.dist = MinimalImageDistance(lattice_vectors)
 
     def electron(self, e):
-        return PeriodicConfigs(self.configs[:, e], self.lvecs, wrap=self.wrap[:, e])
+        return PeriodicElectron(
+            self.configs[:, e], self.lvecs, self.dist, wrap=self.wrap[:, e]
+        )
 
     def mask(self, mask):
         return PeriodicConfigs(self.configs[mask], self.lvecs, wrap=self.wrap[mask])


### PR DESCRIPTION
no need to create a new distance object when calling configs.electron(e). 