### PR TITLE
Speed improvements with GPU

### DIFF
--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -305,8 +305,7 @@ class Ewald:
         sum_e_cos = cp.cos(e_GdotR).sum(axis=1)
         ee_recip = cp.dot(sum_e_sin ** 2 + sum_e_cos ** 2, self.gweight)
         ## Reciprocal space electron-ion part
-        ion_exp = cp.asarray(self.ion_exp)
-        coscos_sinsin = -ion_exp.real * sum_e_cos + ion_exp.imag * sum_e_sin
+        coscos_sinsin = -self.ion_exp.real * sum_e_cos + self.ion_exp.imag * sum_e_sin
         ei_recip = 2 * cp.dot(coscos_sinsin, self.gweight)
         return ee_recip, ei_recip
 
@@ -416,7 +415,7 @@ class Ewald:
         Vtest[:, :-1] += 2 * ee_recip_separated
 
         # Reciprocal space electrin-ion part
-        coscos_sinsin = -ion_exp.real * test_cos + ion_exp.imag * test_sin
+        coscos_sinsin = -self.ion_exp.real * test_cos + self.ion_exp.imag * test_sin
         ei_recip_separated = cp.dot(coscos_sinsin + 0.5, self.gweight)
         Vtest[:, -1] += 2 * ei_recip_separated
 

--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pyqmc
-from scipy.special import erfc
 import pyqmc.energy
-from pyqmc.loadcupy import cp, asnumpy
+from pyqmc.loadcupy import cp, asnumpy, erfc
 
 
 class Ewald:
@@ -86,7 +85,8 @@ class Ewald:
         :parameter int nlatvec: how far to take real-space sum; probably never needs to be changed.
         """
         self.nelec = np.array(cell.nelec)
-        self.atom_coords, self.atom_charges = cell.atom_coords(), cell.atom_charges()
+        self.atom_coords = cell.atom_coords()
+        self.atom_charges = cp.asarray(cell.atom_charges())
         self.latvec = cell.lattice_vectors()
         self.set_lattice_displacements(nlatvec)
         self.set_up_reciprocal_ewald_sum(ewald_gmax)
@@ -99,7 +99,7 @@ class Ewald:
         """
         XYZ = np.meshgrid(*[np.arange(-nlatvec, nlatvec + 1)] * 3, indexing="ij")
         xyz = np.stack(XYZ, axis=-1).reshape((-1, 3))
-        self.lattice_displacements = np.dot(xyz, self.latvec)
+        self.lattice_displacements = cp.asarray(np.dot(xyz, self.latvec))
 
     def set_up_reciprocal_ewald_sum(self, ewald_gmax):
         r"""
@@ -125,16 +125,16 @@ class Ewald:
         print("Setting Ewald alpha to ", self.alpha)
 
         # Determine G points to include in reciprocal Ewald sum
-        X, Y, Z = np.meshgrid(
-            *[np.arange(-ewald_gmax, ewald_gmax + 1)] * 3, indexing="ij"
+        X, Y, Z = cp.meshgrid(
+            *[cp.arange(-ewald_gmax, ewald_gmax + 1)] * 3, indexing="ij"
         )
         positive_octants = X + 1e-6 * Y + 1e-12 * Z > 0  # assume ewald_gmax < 1e5
-        gpoints = np.stack(
+        gpoints = cp.stack(
             (X[positive_octants], Y[positive_octants], Z[positive_octants]), axis=-1
         )
-        gpoints = np.dot(gpoints, recvec) * 2 * np.pi
-        gsquared = np.sum(gpoints ** 2, axis=1)
-        gweight = 4 * np.pi * np.exp(-gsquared / (4 * self.alpha ** 2))
+        gpoints = cp.dot(gpoints, cp.asarray(recvec)) * 2 * np.pi
+        gsquared = cp.sum(gpoints ** 2, axis=1)
+        gweight = 4 * np.pi * cp.exp(-gsquared / (4 * self.alpha ** 2))
         gweight /= cellvolume * gsquared
         bigweight = gweight > 1e-10
         self.gpoints = gpoints[bigweight]
@@ -222,22 +222,24 @@ class Ewald:
         else:
             dist = pyqmc.distance.MinimalImageDistance(self.latvec)
             ion_distances, ion_inds = dist.dist_matrix(self.atom_coords[np.newaxis])
+            ion_distances = cp.asarray(ion_distances)
             rvec = ion_distances[:, :, np.newaxis, :] + self.lattice_displacements
-            r = np.linalg.norm(rvec, axis=-1)
-            charge_ij = np.prod(self.atom_charges[np.asarray(ion_inds)], axis=1)
+            r = cp.linalg.norm(rvec, axis=-1)
+            charge_ij = cp.prod(self.atom_charges[np.asarray(ion_inds)], axis=1)
             ion_ion_real = np.einsum("j,ijk->", charge_ij, erfc(self.alpha * r) / r)
 
         # Reciprocal space part
-        GdotR = np.dot(self.gpoints, self.atom_coords.T)
-        self.ion_exp = np.dot(np.exp(1j * GdotR), self.atom_charges)
-        ion_ion_rec = np.dot(self.gweight, np.abs(self.ion_exp) ** 2)
+        GdotR = cp.dot(self.gpoints, cp.asarray(self.atom_coords.T))
+        self.ion_exp = cp.dot(cp.exp(1j * GdotR), self.atom_charges)
+        ion_ion_rec = cp.dot(self.gweight, cp.abs(self.ion_exp) ** 2)
 
         ion_ion = ion_ion_real + ion_ion_rec
         return ion_ion
 
     def _real_cij(self, dists):
-        r = np.zeros(dists.shape[:-1])
-        cij = np.zeros(r.shape)
+        dists = cp.asarray(dists)
+        r = cp.zeros(dists.shape[:-1])
+        cij = cp.zeros(r.shape)
         for ld in self.lattice_displacements:
             r[:] = np.linalg.norm(dists + ld, axis=-1)
             cij += erfc(self.alpha * r) / r
@@ -278,10 +280,10 @@ class Ewald:
         # ei_distances shape (elec, conf, atom, dim)
         ei_distances = configs.dist.dist_i(self.atom_coords, configs.configs)
         ei_cij = self._real_cij(ei_distances)
-        ei_real_separated = np.einsum("k,ijk->ji", -self.atom_charges, ei_cij)
+        ei_real_separated = cp.einsum("k,ijk->ji", -self.atom_charges, ei_cij)
 
         # Real space electron-electron part
-        ee_real_separated = np.zeros((nconf, nelec))
+        ee_real_separated = cp.zeros((nconf, nelec))
         if nelec > 1:
             ee_distances, ee_inds = configs.dist.dist_matrix(configs.configs)
             ee_cij = self._real_cij(ee_distances)
@@ -298,20 +300,19 @@ class Ewald:
 
     def reciprocal_space_electron(self, configs):
         # Reciprocal space electron-electron part
-        gweight = cp.asarray(self.gweight)
-        e_GdotR = cp.einsum("hik,jk->hij", cp.asarray(configs), cp.asarray(self.gpoints))
+        e_GdotR = cp.einsum("hik,jk->hij", cp.asarray(configs), self.gpoints)
         sum_e_sin = cp.sin(e_GdotR).sum(axis=1)
         sum_e_cos = cp.cos(e_GdotR).sum(axis=1)
-        ee_recip = np.dot(sum_e_sin ** 2 + sum_e_cos ** 2, gweight)
+        ee_recip = cp.dot(sum_e_sin ** 2 + sum_e_cos ** 2, self.gweight)
         ## Reciprocal space electron-ion part
         ion_exp = cp.asarray(self.ion_exp)
         coscos_sinsin = -ion_exp.real * sum_e_cos + ion_exp.imag * sum_e_sin
-        ei_recip = 2 * np.dot(coscos_sinsin, gweight)
-        return asnumpy(ee_recip), asnumpy(ei_recip)
+        ei_recip = 2 * cp.dot(coscos_sinsin, self.gweight)
+        return ee_recip, ei_recip
 
     def reciprocal_space_electron_separated(self, configs):
         # Reciprocal space electron-electron part
-        e_GdotR = np.einsum("hik,jk->hij", configs, self.gpoints)
+        e_GdotR = np.einsum("hik,jk->hij", cp.asarray(configs), self.gpoints)
         e_sin = np.sin(e_GdotR)
         e_cos = np.cos(e_GdotR)
         sinsin = e_sin.sum(axis=1, keepdims=True) * e_sin
@@ -357,7 +358,7 @@ class Ewald:
         ee += self.ee_const(nelec)
         ei += self.ei_const(nelec)
         ii = self.ion_ion + self.ii_const
-        return ee, ei, ii
+        return asnumpy(ee), asnumpy(ei), asnumpy(ii)
 
     def energy_separated(self, configs):
         """
@@ -385,36 +386,41 @@ class Ewald:
         :rtype: (nconf, nelec+1) array
         """
         nconf, nelec, ndim = configs.configs.shape
-        Vtest = np.zeros((nconf, nelec + 1)) + self.ijconst
+        Vtest = cp.zeros((nconf, nelec + 1)) + self.ijconst
         Vtest[:, -1] = self.e_single_test
 
         # Real space electron-ion part
         # ei_distances shape (conf, atom, dim)
         ei_distances = configs.dist.dist_i(self.atom_coords, epos.configs)
+        ei_distances = cp.asarray(ei_distances)
         rvec = ei_distances[:, :, np.newaxis, :] + self.lattice_displacements
-        r = np.linalg.norm(rvec, axis=-1)
-        Vtest[:, -1] += np.einsum(
+        r = cp.linalg.norm(rvec, axis=-1)
+        Vtest[:, -1] += cp.einsum(
             "k,jkl->j", -self.atom_charges, erfc(self.alpha * r) / r
         )
 
         # Real space electron-electron part
         ee_distances = configs.dist.dist_i(configs.configs, epos.configs)
+        ee_distances = cp.asarray(ee_distances)
         rvec = ee_distances[:, :, np.newaxis, :] + self.lattice_displacements
-        r = np.linalg.norm(rvec, axis=-1)
-        Vtest[:, :-1] += np.sum(erfc(self.alpha * r) / r, axis=-1)
+        r = cp.linalg.norm(rvec, axis=-1)
+        Vtest[:, :-1] += cp.sum(erfc(self.alpha * r) / r, axis=-1)
 
         # Reciprocal space electron-electron part
-        e_expGdotR = np.exp(1j * np.dot(configs.configs, self.gpoints.T))
-        test_exp = np.exp(1j * np.dot(epos.configs, self.gpoints.T))
-        ee_recip_separated = np.dot(np.real(test_exp.conj() * e_expGdotR), self.gweight)
+        GdotR = cp.dot(cp.asarray(configs.configs), self.gpoints.T)
+        testGdotR = cp.dot(cp.asarray(epos.configs), self.gpoints.T)
+        test_cos = cp.cos(testGdotR)
+        test_sin = cp.sin(testGdotR)
+        coscos_sinsin = cp.cos(GdotR) * test_cos + cp.sin(GdotR) * test_sin
+        ee_recip_separated = cp.dot(coscos_sinsin, self.gweight)
         Vtest[:, :-1] += 2 * ee_recip_separated
 
         # Reciprocal space electrin-ion part
-        coscos_sinsin = np.real(-self.ion_exp.conj() * test_exp)
-        ei_recip_separated = np.dot(coscos_sinsin + 0.5, self.gweight)
+        coscos_sinsin = -ion_exp.real * test_cos + ion_exp.imag * test_sin
+        ei_recip_separated = cp.dot(coscos_sinsin + 0.5, self.gweight)
         Vtest[:, -1] += 2 * ei_recip_separated
 
-        return Vtest
+        return asnumpy(Vtest)
 
     def compute_total_energy(self, mol, configs, wf, threshold):
         """

--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -2,6 +2,7 @@ import numpy as np
 import pyqmc
 from scipy.special import erfc
 import pyqmc.energy
+from pyqmc.loadcupy import cp, asnumpy
 
 
 class Ewald:
@@ -296,14 +297,16 @@ class Ewald:
 
     def reciprocal_space_electron(self, configs):
         # Reciprocal space electron-electron part
-        e_GdotR = np.einsum("hik,jk->hij", configs, self.gpoints)
-        sum_e_sin = np.sin(e_GdotR).sum(axis=1)
-        sum_e_cos = np.cos(e_GdotR).sum(axis=1)
-        ee_recip = np.dot(sum_e_sin ** 2 + sum_e_cos ** 2, self.gweight)
+        gweight = cp.asarray(self.gweight)
+        e_GdotR = cp.einsum("hik,jk->hij", cp.asarray(configs), cp.asarray(self.gpoints))
+        sum_e_sin = cp.sin(e_GdotR).sum(axis=1)
+        sum_e_cos = cp.cos(e_GdotR).sum(axis=1)
+        ee_recip = np.dot(sum_e_sin ** 2 + sum_e_cos ** 2, gweight)
         ## Reciprocal space electron-ion part
-        coscos_sinsin = -self.ion_exp.real * sum_e_cos + self.ion_exp.imag * sum_e_sin
-        ei_recip = 2 * np.dot(coscos_sinsin, self.gweight)
-        return ee_recip, ei_recip
+        ion_exp = cp.asarray(self.ion_exp)
+        coscos_sinsin = -ion_exp.real * sum_e_cos + ion_exp.imag * sum_e_sin
+        ei_recip = 2 * np.dot(coscos_sinsin, gweight)
+        return asnumpy(ee_recip), asnumpy(ei_recip)
 
     def reciprocal_space_electron_separated(self, configs):
         # Reciprocal space electron-electron part

--- a/pyqmc/linemin.py
+++ b/pyqmc/linemin.py
@@ -152,7 +152,7 @@ def line_minimization(
     def gradient_energy_function(x, coords):
         newparms = pgrad_acc.transform.deserialize(x)
         for k in newparms:
-            wf.parameters[k] = cp.asarray(newparms[k])
+            wf.parameters[k] = newparms[k]
         df, coords = pyqmc.mc.vmc(
             wf,
             coords,
@@ -242,7 +242,7 @@ def line_minimization(
 
     newparms = pgrad_acc.transform.deserialize(x0)
     for k in newparms:
-        wf.parameters[k] = cp.asarray(newparms[k])
+        wf.parameters[k] = newparms[k]
 
     return wf, df
 
@@ -266,7 +266,7 @@ def correlated_compute(wf, configs, params, pgrad_acc):
     for p in params:
         newparms = pgrad_acc.transform.deserialize(p)
         for k in newparms:
-            wf.parameters[k] = cp.asarray(newparms[k])
+            wf.parameters[k] = newparms[k]
         psi = wf.recompute(configs)[1]  # recompute gives logdet
         rawweights = np.exp(2 * (psi - psi0))  # convert from log(|psi|) to |psi|**2
         df = pgrad_acc.enacc(configs, wf)

--- a/pyqmc/linemin.py
+++ b/pyqmc/linemin.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pyqmc.loadcupy import cp, get_array_module, asnumpy
+from pyqmc.loadcupy import cp, asnumpy
 import scipy
 import h5py
 import os
@@ -151,8 +151,6 @@ def line_minimization(
     if update_kws is None:
         update_kws = {}
 
-    array_module = {k: get_array_module(v) for k, v in wf.parameters.items()}
-
     # Restart
     iteration_offset = 0
     if hdf_file is not None and os.path.isfile(hdf_file):
@@ -160,7 +158,7 @@ def line_minimization(
             if "wf" in hdf.keys():
                 grp = hdf["wf"]
                 for k in grp.keys():
-                    wf.parameters[k] = array_module[k].array(grp[k])
+                    wf.parameters[k] = cp.asarray(grp[k])
             if "iteration" in hdf.keys():
                 iteration_offset = np.max(hdf["iteration"][...]) + 1
 
@@ -170,7 +168,7 @@ def line_minimization(
     def gradient_energy_function(x, coords):
         newparms = pgrad_acc.transform.deserialize(x)
         for k in newparms:
-            wf.parameters[k] = array_module[k].asarray(newparms[k])
+            wf.parameters[k] = cp.asarray(newparms[k])
         df, coords = pyqmc.mc.vmc(
             wf,
             coords,
@@ -260,7 +258,7 @@ def line_minimization(
 
     newparms = pgrad_acc.transform.deserialize(x0)
     for k in newparms:
-        wf.parameters[k] = array_module[k].asarray(newparms[k])
+        wf.parameters[k] = cp.asarray(newparms[k])
 
     return wf, df
 
@@ -284,12 +282,11 @@ def correlated_compute(wf, configs, params, pgrad_acc):
 
     data = []
     psi0 = wf.recompute(configs)[1]  # recompute gives logdet
-    array_module = {k: get_array_module(v) for k, v in wf.parameters.items()}
 
     for p in params:
         newparms = pgrad_acc.transform.deserialize(p)
         for k in newparms:
-            wf.parameters[k] = array_module[k].asarray(newparms[k])
+            wf.parameters[k] = cp.asarray(newparms[k])
         psi = wf.recompute(configs)[1]  # recompute gives logdet
         rawweights = np.exp(2 * (psi - psi0))  # convert from log(|psi|) to |psi|**2
         df = pgrad_acc.enacc(configs, wf)

--- a/pyqmc/loadcupy.py
+++ b/pyqmc/loadcupy.py
@@ -1,7 +1,12 @@
+class NoGPUFoundError(Exception):
+    pass
+
 try:
     import cupy as cp
     from cupy import get_array_module, asnumpy, fuse
-except ModuleNotFoundError as e:
+    if not cp.cuda.is_available():
+        raise NoGPUFoundError
+except (ModuleNotFoundError, NoGPUFoundError) as e:
     import numpy as cp
 
     def get_array_module(a):

--- a/pyqmc/loadcupy.py
+++ b/pyqmc/loadcupy.py
@@ -1,13 +1,17 @@
 class NoGPUFoundError(Exception):
     pass
 
+
 try:
     import cupy as cp
     from cupy import get_array_module, asnumpy, fuse
+    from cupyx.scipy.special import erfc
+
     if not cp.cuda.is_available():
         raise NoGPUFoundError
 except (ModuleNotFoundError, NoGPUFoundError) as e:
     import numpy as cp
+    from scipy.special import erfc
 
     def get_array_module(a):
         return cp

--- a/pyqmc/mc.py
+++ b/pyqmc/mc.py
@@ -111,7 +111,8 @@ def vmc_worker(wf, configs, tstep, nsteps, accumulators):
         acc = 0.0
         for e in range(nelec):
             # Propose move
-            grad = limdrift(np.real(wf.gradient(e, configs.electron(e)).T))
+            g, _ = wf.gradient_value(e, configs.electron(e))
+            grad = limdrift(np.real(g.T))
             gauss = np.random.normal(scale=np.sqrt(tstep), size=(nconf, 3))
             newcoorde = configs.configs[:, e, :] + gauss + grad * tstep
             newcoorde = configs.make_irreducible(e, newcoorde)

--- a/pyqmc/pbc_eval_gto.py
+++ b/pyqmc/pbc_eval_gto.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Qiming Sun <osirpt.sun@gmail.com>
+# Modified by Will Wheeler <willwheelera@gmail.com> for use in PyQMC
+
+import ctypes
+import numpy
+from pyscf import lib
+from pyscf.gto import moleintor
+from pyscf.gto.eval_gto import _get_intor_and_comp
+from pyscf.pbc.gto import _pbcintor
+from pyscf import __config__
+
+BLKSIZE = 128  # needs to be the same to lib/gto/grid_ao_drv.c
+EXTRA_PREC = getattr(__config__, "pbc_gto_eval_gto_extra_precision", 1e-2)
+
+libpbc = _pbcintor.libpbc
+
+
+def get_lattice_Ls(cell):
+    if cell.dimension < 2 or cell.low_dim_ft_type == "inf_vacuum":
+        Ls = cell.get_lattice_Ls(dimension=cell.dimension)
+    else:
+        Ls = cell.get_lattice_Ls(dimension=3)
+    return Ls[numpy.argsort(lib.norm(Ls, axis=1))]
+
+
+def eval_gto(
+    cell,
+    eval_name,
+    coords,
+    comp=None,
+    kpts=None,
+    kpt=None,
+    shls_slice=None,
+    non0tab=None,
+    ao_loc=None,
+    out=None,
+    Ls=None,
+    rcut=None,
+):
+    r"""Evaluate PBC-AO function value on the given grids,
+
+    Args:
+        eval_name : str
+
+            ==========================  =======================
+            Function                    Expression
+            ==========================  =======================
+            "GTOval_sph"                \sum_T exp(ik*T) |AO>
+            "GTOval_ip_sph"             nabla \sum_T exp(ik*T) |AO>
+            "GTOval_cart"               \sum_T exp(ik*T) |AO>
+            "GTOval_ip_cart"            nabla \sum_T exp(ik*T) |AO>
+            ==========================  =======================
+
+        atm : int32 ndarray
+            libcint integral function argument
+        bas : int32 ndarray
+            libcint integral function argument
+        env : float64 ndarray
+            libcint integral function argument
+
+        coords : 2D array, shape (N,3)
+            The coordinates of the grids.
+
+    Kwargs:
+        shls_slice : 2-element list
+            (shl_start, shl_end).
+            If given, only part of AOs (shl_start <= shell_id < shl_end) are
+            evaluated.  By default, all shells defined in cell will be evaluated.
+        non0tab : 2D bool array
+            mask array to indicate whether the AO values are zero.  The mask
+            array can be obtained by calling :func:`dft.gen_grid.make_mask`
+        out : ndarray
+            If provided, results are written into this array.
+
+    Returns:
+        A list of 2D (or 3D) arrays to hold the AO values on grids.  Each
+        element of the list corresponds to a k-point and it has the shape
+        (N,nao) Or shape (\*,N,nao).
+
+    Examples:
+
+    >>> cell = pbc.gto.M(a=numpy.eye(3)*4, atom='He 1 1 1', basis='6-31g')
+    >>> coords = cell.get_uniform_grids([20,20,20])
+    >>> kpts = cell.make_kpts([3,3,3])
+    >>> ao_value = cell.pbc_eval_gto("GTOval_sph", coords, kpts)
+    >>> len(ao_value)
+    27
+    >>> ao_value[0].shape
+    (100, 2)
+    >>> ao_value = cell.pbc_eval_gto("GTOval_ig_sph", coords, kpts, comp=3)
+    >>> print(ao_value.shape)
+    >>> len(ao_value)
+    27
+    >>> ao_value[0].shape
+    (3, 100, 2)
+    """
+    if eval_name[:3] == "PBC":  # PBCGTOval_xxx
+        eval_name, comp = _get_intor_and_comp(cell, eval_name[3:], comp)
+    else:
+        eval_name, comp = _get_intor_and_comp(cell, eval_name, comp)
+    eval_name = "PBC" + eval_name
+
+    atm = numpy.asarray(cell._atm, dtype=numpy.int32, order="C")
+    bas = numpy.asarray(cell._bas, dtype=numpy.int32, order="C")
+    env = numpy.asarray(cell._env, dtype=numpy.double, order="C")
+    natm = atm.shape[0]
+    nbas = bas.shape[0]
+    if kpts is None:
+        if kpt is not None:
+            kpts_lst = numpy.reshape(kpt, (1, 3))
+        else:
+            kpts_lst = numpy.zeros((1, 3))
+    else:
+        kpts_lst = numpy.reshape(kpts, (-1, 3))
+    nkpts = len(kpts_lst)
+    ngrids = len(coords)
+
+    if non0tab is None:
+        non0tab = numpy.empty(
+            ((ngrids + BLKSIZE - 1) // BLKSIZE, nbas), dtype=numpy.uint8
+        )
+        # non0tab stores the number of images to be summed in real space.
+        # Initializing it to 255 means all images are summed
+        non0tab[:] = 0xFF
+
+    if ao_loc is None:
+        ao_loc = moleintor.make_loc(bas, eval_name)
+    if shls_slice is None:
+        shls_slice = (0, nbas)
+    sh0, sh1 = shls_slice
+    nao = ao_loc[sh1] - ao_loc[sh0]
+
+    out = numpy.empty((nkpts, comp, nao, ngrids), dtype=numpy.complex128)
+    coords = numpy.asarray(coords, order="F")
+
+    # For atoms near the boundary of the cell, it is necessary (even in low-
+    # dimensional systems) to include lattice translations in all 3 dimensions.
+    if Ls is None:
+        if cell.dimension < 2 or cell.low_dim_ft_type == "inf_vacuum":
+            Ls = cell.get_lattice_Ls(dimension=cell.dimension)
+        else:
+            Ls = cell.get_lattice_Ls(dimension=3)
+        Ls = Ls[numpy.argsort(lib.norm(Ls, axis=1))]
+    expLk = numpy.exp(1j * numpy.asarray(numpy.dot(Ls, kpts_lst.T), order="C"))
+    if rcut is None:
+        rcut = _estimate_rcut(cell)
+
+    drv = getattr(libpbc, eval_name)
+    drv(
+        ctypes.c_int(ngrids),
+        (ctypes.c_int * 2)(*shls_slice),
+        ao_loc.ctypes.data_as(ctypes.c_void_p),
+        Ls.ctypes.data_as(ctypes.c_void_p),
+        ctypes.c_int(len(Ls)),
+        expLk.ctypes.data_as(ctypes.c_void_p),
+        ctypes.c_int(nkpts),
+        out.ctypes.data_as(ctypes.c_void_p),
+        coords.ctypes.data_as(ctypes.c_void_p),
+        rcut.ctypes.data_as(ctypes.c_void_p),
+        non0tab.ctypes.data_as(ctypes.c_void_p),
+        atm.ctypes.data_as(ctypes.c_void_p),
+        ctypes.c_int(natm),
+        bas.ctypes.data_as(ctypes.c_void_p),
+        ctypes.c_int(nbas),
+        env.ctypes.data_as(ctypes.c_void_p),
+    )
+
+    ao_kpts = []
+    for k, kpt in enumerate(kpts_lst):
+        v = out[k]
+        if abs(kpt).sum() < 1e-9:
+            v = numpy.asarray(v.real, order="C")
+        v = v.transpose(0, 2, 1)
+        if comp == 1:
+            v = v[0]
+        ao_kpts.append(v)
+
+    if kpts is None or numpy.shape(kpts) == (3,):  # A single k-point
+        ao_kpts = ao_kpts[0]
+    return ao_kpts
+
+
+pbc_eval_gto = eval_gto
+
+
+def _estimate_rcut(cell):
+    """Cutoff raidus, above which each shell decays to a value less than the
+    required precsion"""
+    log_prec = numpy.log(cell.precision * EXTRA_PREC)
+    rcut = []
+    for ib in range(cell.nbas):
+        l = cell.bas_angular(ib)
+        es = cell.bas_exp(ib)
+        cs = abs(cell.bas_ctr_coeff(ib)).max(axis=1)
+        r = 5.0
+        r = (((l + 2) * numpy.log(r) + numpy.log(cs) - log_prec) / es) ** 0.5
+        r = (((l + 2) * numpy.log(r) + numpy.log(cs) - log_prec) / es) ** 0.5
+        rcut.append(r.max())
+    return numpy.array(rcut)
+
+
+if __name__ == "__main__":
+    from pyscf.pbc import gto
+
+    cell = gto.M(a=numpy.eye(3) * 4, atom="He 1 1 1", basis=[[2, (1, 0.5), (0.5, 0.5)]])
+    coords = cell.get_uniform_grids([10] * 3)
+    ao_value = eval_gto(cell, "GTOval_sph", coords, kpts=cell.make_kpts([3] * 3))
+    print(
+        lib.finger(numpy.asarray(ao_value))
+        - (-0.27594803231989179 + 0.0064644591759109114j)
+    )
+
+    cell = gto.M(a=numpy.eye(3) * 4, atom="He 1 1 1", basis=[[2, (1, 0.5), (0.5, 0.5)]])
+    coords = cell.get_uniform_grids([10] * 3)
+    ao_value = eval_gto(cell, "GTOval_ip_cart", coords, kpts=cell.make_kpts([3] * 3))
+    print(
+        lib.finger(numpy.asarray(ao_value))
+        - (0.38051517609460028 + 0.062526488684770759j)
+    )

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -194,15 +194,15 @@ class Slater:
         dnref = cp.amax(self._dets[1][1]).real
 
         det_array = (
-            self._dets[0][0, :, self._det_map[0]][:, mask]
-            * self._dets[1][0, :, self._det_map[1]][:, mask]
+            self._dets[0][0, mask][:, self._det_map[0]]
+            * self._dets[1][0, mask][:, self._det_map[1]]
             * cp.exp(
-                self._dets[0][1, :, self._det_map[0]][:, mask]
-                + self._dets[1][1, :, self._det_map[1]][:, mask]
+                self._dets[0][1, mask][:, self._det_map[0]]
+                + self._dets[1][1, mask][:, self._det_map[1]]
                 - upref
                 - dnref
             )
-        )
+        ).T
         numer = cp.einsum(
             "i...d,d,di->i...",
             ratios[..., self._det_map[s]],


### PR DESCRIPTION
some small changes for small speed improvements:
- use GPU for Ewald reciprocal_space_electron 
- replace gradient() with gradient_value() in vmc (maybe we can drop the gradient() function)
- mask determinant lists before expanding det_map instead of after

cleanup: remove get_array_module from linemin, since all wf parameters are cupy