### PR TITLE
fix loadcupy

### DIFF
--- a/pyqmc/loadcupy.py
+++ b/pyqmc/loadcupy.py
@@ -1,7 +1,12 @@
+class NoGPUFoundError(Exception):
+    pass
+
 try:
     import cupy as cp
     from cupy import get_array_module, asnumpy, fuse
-except ModuleNotFoundError as e:
+    if not cp.cuda.is_available():
+        raise NoGPUFoundError
+except (ModuleNotFoundError, NoGPUFoundError) as e:
     import numpy as cp
 
     def get_array_module(a):


### PR DESCRIPTION
if cupy is available but no GPU is available, a ModuleNotFoundError will not be raised, but a RuntimeError will be raised when cupy attempts to allocate an array. To catch this more cleanly than the original implementation, this PR uses the cupy.cuda.is_available() function and raises a custom-defined NoGPUFoundError.  