### PR TITLE
Add "locally piecewise-quintic Hermite interpolant" func3d basis function

### DIFF
--- a/tests/unit/test_func3d_derivatives.py
+++ b/tests/unit/test_func3d_derivatives.py
@@ -6,7 +6,8 @@ import pyqmc.func3d as func3d
                           [func3d.PadeFunction(0.2),
                            func3d.PolyPadeFunction(2.0, 1.5),
                            func3d.CutoffCuspFunction(2.0, 1.5),
-                           func3d.GaussianFunction(0.4) ])
+                           func3d.GaussianFunction(0.4),
+                           func3d.LPQHI.initialize_random(4, 1.5) ])
 def test_func3d(func, delta=1e-6, epsilon=1e-5):
     """
     Ensure that the 3-dimensional functions correctly compute their gradient and laplacian


### PR DESCRIPTION
from Natoli and Ceperley https://doi-org.proxy2.library.illinois.edu/10.1006/jcph.1995.1054
The function is defined on an interval [0, rcut], which is divided into segments of length D
f(r) = sum_n t_n h_n(r), where t_n is a set of coefficients, and h_n(r) is a narrow function that goes smoothly to zero at distance D away from the center. I've included all the small basis functions h_n(r) and the parameter array t for efficient evaluation, instead of defining a single basis function h(r) and leaving the t_n as (e.g.) Jastrow coefficients.