### PR TITLE
fix ewald sign error and add new test

### DIFF
--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -309,7 +309,7 @@ class Ewald:
         sum_e_cos = gpu.cp.cos(e_GdotR).sum(axis=1)
         ee_recip = gpu.cp.dot(sum_e_sin ** 2 + sum_e_cos ** 2, self.gweight)
         ## Reciprocal space electron-ion part
-        coscos_sinsin = -self.ion_exp.real * sum_e_cos + self.ion_exp.imag * sum_e_sin
+        coscos_sinsin = -self.ion_exp.real * sum_e_cos - self.ion_exp.imag * sum_e_sin
         ei_recip = 2 * gpu.cp.dot(coscos_sinsin, self.gweight)
         return ee_recip, ei_recip
 


### PR DESCRIPTION
ewald was giving different e-i energy for different ion positions, due to a flipped minus sign. This has been fixed. 

A test was added to check that the ee, ei, ii terms are the same when an atom is shifted in the cell.