### PR TITLE
Manual specification of determinants

### DIFF
--- a/pyqmc/determinant_tools.py
+++ b/pyqmc/determinant_tools.py
@@ -113,6 +113,29 @@ def create_packed_objects(deters, ncore=0, tol=0, format='binary'):
     return np.array(detwt), occup, np.array(map_dets)
 
 
+def create_pbc_determinant(mol, mf, excitations):
+    """
+    excitations should be a list of tuples with 
+    (s,ka,a,ki,i),  
+    s is the spin (0 or 1), 
+    ka, a is the occupied orbital, 
+    and ki, i is the unoccupied orbital.
+    """
+    if len(mf.mo_coeff[0][0].shape) == 2:
+        occupation = [
+            [list(np.nonzero(occ > 0.9)[0]) for occ in mf.mo_occ[s]]
+            for s in range(2)]
+    elif len(mf.mo_coeff[0][0].shape) == 1:
+            occupation = [ 
+            [list(np.nonzero(occ > 1.9-s)[0]) for occ in mf.mo_occ]
+            for s in range(2)]
+
+    for s,ka,a,ki,i in excitations:
+        occupation[s][ka].remove(a)
+        occupation[s][ki].append(i)
+    return occupation
+
+
 def compute_value(updets, dndets, det_coeffs):
     """
     Given the up and down determinant values, safely compute the total log wave function.

--- a/pyqmc/determinant_tools.py
+++ b/pyqmc/determinant_tools.py
@@ -73,8 +73,12 @@ def interpret_ci(mc, tol):
 
 def create_packed_objects(deters, ncore=0, tol=0, format='binary'):
     """
+    if format == "binary":
     deters is expected to be an iterable of tuples, each of which is 
     (weight, occupation string up, occupation_string down)
+    if format == "list"
+    (weight, occupation)
+    where occupation is a nested list [s][0, 1, 2, 3 ..], for example.
 
     ncore should be the number of core orbitals not included in the occupation strings.
     tol is the threshold at which to include the determinants
@@ -95,8 +99,8 @@ def create_packed_objects(deters, ncore=0, tol=0, format='binary'):
                 alpha_occ, __ = binary_to_occ(x[1], ncore)
                 beta_occ, __ = binary_to_occ(x[2], ncore)
             elif format=='list':
-                alpha_occ = x[1]
-                beta_occ = x[2]
+                alpha_occ = x[1][0]
+                beta_occ = x[1][1]
             else:
                 raise ValueError("create_packed_objects: Options for format are binary or list")
             if alpha_occ not in occup[0]:

--- a/pyqmc/determinant_tools.py
+++ b/pyqmc/determinant_tools.py
@@ -41,8 +41,6 @@ def determinants_from_mean_field(mf):
 def deters_from_hci(mc, tol):
     bigcis = np.abs(mc.ci) > tol
     nstrs = int(mc._strs.shape[1] / 2)
-    # old code for single strings.
-    # deters = [(c,bin(s[0]), bin(s[1])) for c, s in zip(mc.ci[bigcis],mc._strs[bigcis,:])]
     deters = []
     # In pyscf, the first n/2 strings represent the up determinant and the second
     # represent the down determinant.

--- a/pyqmc/determinant_tools.py
+++ b/pyqmc/determinant_tools.py
@@ -57,9 +57,6 @@ def interpret_ci(mc, tol):
     Copies over determinant coefficients and MO occupations
     for a multi-configuration calculation mc.
 
-    This implementation separates the up and down determinants, so that we only have to compute
-
-
     returns:
     detwt: array of weights for each determinant
     occup: which orbitals go in which determinants
@@ -74,7 +71,7 @@ def interpret_ci(mc, tol):
     return create_packed_objects(deters, ncore, tol)
 
 
-def create_packed_objects(deters, ncore=0, tol=0):
+def create_packed_objects(deters, ncore=0, tol=0, format='binary'):
     """
     deters is expected to be an iterable of tuples, each of which is 
     (weight, occupation string up, occupation_string down)
@@ -94,8 +91,14 @@ def create_packed_objects(deters, ncore=0, tol=0):
     for x in deters:
         if np.abs(x[0]) > tol:
             detwt.append(x[0])
-            alpha_occ, __ = binary_to_occ(x[1], ncore)
-            beta_occ, __ = binary_to_occ(x[2], ncore)
+            if format=='binary':
+                alpha_occ, __ = binary_to_occ(x[1], ncore)
+                beta_occ, __ = binary_to_occ(x[2], ncore)
+            elif format=='list':
+                alpha_occ = x[1]
+                beta_occ = x[2]
+            else:
+                raise ValueError("create_packed_objects: Options for format are binary or list")
             if alpha_occ not in occup[0]:
                 map_dets[0].append(len(occup[0]))
                 occup[0].append(alpha_occ)

--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -119,7 +119,6 @@ class Ewald:
         # Determine alpha
         smallestheight = np.amin(1 / np.linalg.norm(recvec.T, axis=1))
         self.alpha = 5.0 / smallestheight
-        print("Setting Ewald alpha to ", self.alpha)
 
         # Determine G points to include in reciprocal Ewald sum
         gptsXpos = gpu.cp.meshgrid(

--- a/pyqmc/jastrowspin.py
+++ b/pyqmc/jastrowspin.py
@@ -51,7 +51,7 @@ class JastrowSpin:
         self._avalues = gpu.cp.zeros((nconf, self._mol.natm, aexpand, 2))
         self._a_partial = gpu.cp.zeros((nelec, nconf, self._mol.natm, aexpand))
         self._b_partial = gpu.cp.zeros((nelec, nconf, nexpand, 2))
-        notmask = [True] * nconf
+        notmask = np.ones(nconf, dtype=bool)
         for e in range(nelec):
             epos = configs.electron(e)
             self._a_partial[e] = self._a_update(e, epos, notmask)
@@ -165,7 +165,6 @@ class JastrowSpin:
               epos: configs object for electron e
               mask: mask over configs axis, only return values for configs where mask==True. b_partial_e might have a smaller configs axis than epos, _configscurrent, and _b_partial because of the mask.
         """
-        # print(type(epos), epos.configs.shape)
         nup = self._mol.nelec[0]
         d = gpu.cp.asarray(
             epos.dist.dist_i(self._configscurrent.configs[mask], epos.configs[mask])
@@ -175,7 +174,6 @@ class JastrowSpin:
 
         for l, b in enumerate(self.b_basis):
             bval = b.value(d, r)
-            # print("bval", bval.shape, d.shape, r.shape)
             b_partial_e[..., l, 0] = bval[..., :nup].sum(axis=-1)
             b_partial_e[..., l, 1] = bval[..., nup:].sum(axis=-1)
             # b_partial_e[..., l, spin] -= bval[..., e].T

--- a/pyqmc/obdm.py
+++ b/pyqmc/obdm.py
@@ -71,18 +71,21 @@ class OBDMAccumulator:
         else:
             self._electrons = np.arange(0, np.sum(mol.nelec))
 
-        self.iscomplex = bool(sum(map(np.iscomplexobj, orb_coeff)))
 
         if kpts is None:
             self.orbitals = pyqmc.orbitals.MoleculeOrbitalEvaluator(
                 mol, [orb_coeff, orb_coeff]
             )
+            if hasattr(mol,"a"):
+                raise ValueError("kpts is required if the system is periodic")
         else:
             if not hasattr(mol, "original_cell"):
                 mol = supercell.get_supercell(mol, np.eye(3))
             self.orbitals = pyqmc.orbitals.PBCOrbitalEvaluatorKpoints(
                 mol, [orb_coeff, orb_coeff], kpts
             )
+
+        self.iscomplex = self.orbitals.iscomplex
 
         self._tstep = tstep
         self.nelec = len(self._electrons)

--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -146,7 +146,7 @@ def select_orbitals_kpoints(determinants, mf, kinds):
     and the determinants. 
     The determinant indices are flattened so that the indices refer to the concatenated MO coefficients. 
     """
-    max_orb = [[[np.max(orb_k)+1 for orb_k in spin] for spin in det] for wt, det in determinants]
+    max_orb = [[[np.max(orb_k)+1 if len(orb_k) >0 else 0 for orb_k in spin ] for spin in det] for wt, det in determinants]
     max_orb = np.amax(max_orb, axis=0)
 
     if len(mf.mo_coeff[0][0].shape) == 2:

--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -124,9 +124,6 @@ def get_k_indices(cell, mf, kpts, tol=1e-6):
     return np.nonzero(np.linalg.norm(kdiffs, axis=-1) < tol)[1]
 
 
-
-
-
 def pbc_single_determinant(mf, kinds):
     detcoeff = np.array([1.0])
     det_map = np.array([[0], [0]])
@@ -167,7 +164,7 @@ def select_orbitals_kpoints(determinants, mf, kinds):
         for det_s, offset_s in zip(det, orb_offsets):
             flattened=np.array([det_s[k] + offset_s[ki] for ki, k in enumerate(kinds)]).flatten()
             flattened_det.append(list(flattened))
-        determinants_flat.append( (wt, flattened_det[0], flattened_det[1]))
+        determinants_flat.append( (wt, flattened_det))
     return mo_coeff, determinants_flat
 
 class PBCOrbitalEvaluatorKpoints:

--- a/pyqmc/recipes.py
+++ b/pyqmc/recipes.py
@@ -49,9 +49,9 @@ def OPTIMIZE(
 def generate_accumulators(mol, mf, energy=True, rdm1=False, extra_accumulators=None):
     acc = {} if extra_accumulators is None else extra_accumulators
 
-    if hasattr(mf.mo_coeff, "shape") and len(mf.mo_coeff.shape) == 2:
+    if hasattr(mf, "kpts") and len(mf.mo_coeff[0][0].shape) < 2:
         mo_coeff = [mf.mo_coeff, mf.mo_coeff]
-    elif hasattr(mf, "kpts") and len(mf.mo_coeff[0][0].shape) < 2:
+    elif hasattr(mf.mo_coeff, "shape") and len(mf.mo_coeff.shape) == 2:
         mo_coeff = [mf.mo_coeff, mf.mo_coeff]
     else:
         mo_coeff = mf.mo_coeff
@@ -61,10 +61,6 @@ def generate_accumulators(mol, mf, energy=True, rdm1=False, extra_accumulators=N
             raise Exception("Found energy in extra_accumulators and energy is True")
         acc["energy"] = pyqmc.accumulators.EnergyAccumulator(mol)
     if rdm1:
-        if len(mf.mo_coeff.shape) == 2:
-            mo_coeff = [mf.mo_coeff, mf.mo_coeff]
-        else:
-            mo_coeff = mf.mo_coeff
         if "rdm1_up" in acc.keys() or "rdm1_down" in acc.keys():
             raise Exception(
                 "Found rdm1_up or rdm1_down in extra_accumulators and rdm1 is True"

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -102,10 +102,12 @@ class Slater:
 
     def __init__(self, mol, mf, mc=None, tol=None, twist=None, determinants=None):
         """
-        Determinants should be a list of tuples, for example 
+        determinants should be a list of tuples, for example 
         [ (1.0, [0,1],[0,1]),
           (-0.2, [0,2],[0,2]) ] 
         would be a two-determinant wave function with a doubles excitation in the second one. 
+
+        determinants overrides any information in mc, if passed. 
         """
         self.tol = -1 if tol is None else tol
         self._mol = mol
@@ -121,13 +123,7 @@ class Slater:
             self._det_occup,
             self._det_map,
             self.orbitals,
-        ) = pyqmc.orbitals.choose_evaluator_from_pyscf(mol, mf, mc, twist=twist)
-
-        if determinants is not None:
-            (self.myparameters["det_coeff"],
-            self._det_occup,
-            self._det_map ) = pyqmc.determinant_tools.create_packed_objects(determinants, tol, format='list')
-            
+        ) = pyqmc.orbitals.choose_evaluator_from_pyscf(mol, mf, mc, twist=twist, determinants=determinants)           
 
         self.parameters = JoinParameters([self.myparameters, self.orbitals.parameters])
 

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -127,7 +127,7 @@ class Slater:
 
         self.parameters = JoinParameters([self.myparameters, self.orbitals.parameters])
 
-        self.iscomplex = bool(sum(map(gpu.cp.iscomplexobj, self.parameters.values())))
+        self.iscomplex = self.orbitals.iscomplex or bool(sum(map(gpu.cp.iscomplexobj, self.parameters.values())))
         self.dtype = complex if self.iscomplex else float
         self.get_phase = get_complex_phase if self.iscomplex else gpu.cp.sign
 

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -100,7 +100,13 @@ class Slater:
 
     """
 
-    def __init__(self, mol, mf, mc=None, tol=None, twist=None):
+    def __init__(self, mol, mf, mc=None, tol=None, twist=None, determinants=None):
+        """
+        Determinants should be a list of tuples, for example 
+        [ (1.0, [0,1],[0,1]),
+          (-0.2, [0,2],[0,2]) ] 
+        would be a two-determinant wave function with a doubles excitation in the second one. 
+        """
         self.tol = -1 if tol is None else tol
         self._mol = mol
         if hasattr(mc, "nelecas"):
@@ -116,6 +122,13 @@ class Slater:
             self._det_map,
             self.orbitals,
         ) = pyqmc.orbitals.choose_evaluator_from_pyscf(mol, mf, mc, twist=twist)
+
+        if determinants is not None:
+            (self.myparameters["det_coeff"],
+            self._det_occup,
+            self._det_map ) = pyqmc.determinant_tools.create_packed_objects(determinants, tol, format='list')
+            
+
         self.parameters = JoinParameters([self.myparameters, self.orbitals.parameters])
 
         self.iscomplex = bool(sum(map(gpu.cp.iscomplexobj, self.parameters.values())))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,18 @@ def H_pbc_sto3g_krks():
 
 
 @pytest.fixture(scope='module')
+def H_pbc_sto3g_kuks():
+    mol = pyscf.pbc.gto.M(
+        atom="H 0. 0. 0.; H 1. 1. 1.",
+        basis="sto-3g",
+        unit="bohr",
+        a=(np.ones((3, 3)) - np.eye(3)) * 4,
+    )
+    mf = pyscf.pbc.scf.KUKS(mol, mol.make_kpts((2, 2, 2))).run()
+    return mol, mf
+
+
+@pytest.fixture(scope='module')
 def li_cubic_ccecp():
     nk = (2,2,2)
     L = 6.63 * 2

--- a/tests/unit/test_constraints.py
+++ b/tests/unit/test_constraints.py
@@ -1,38 +1,34 @@
-# This must be done BEFORE importing numpy or anything else.
-# Therefore it must be in your main script.
-import pandas as pd
 import numpy as np
-from pyscf import lib, gto, scf, mcscf
 import pyqmc.api as pyq
 from pyqmc.accumulators import LinearTransform
-from pyqmc.coord import OpenConfigs
+import copy
 
-
-def test():
-    # Default multi-Slater wave function
-    mol = gto.M(atom="Li 0. 0. 0.; H 0. 0. 1.5", basis="cc-pvtz", unit="bohr", spin=0)
-    mf = scf.RHF(mol).run()
-    mc = mcscf.CASCI(mf, ncas=2, nelecas=(1, 1))
-    mc.kernel()
+def test_constraints(H2_ccecp_casci_s0):
+    mol, mf, mc = H2_ccecp_casci_s0
 
     wf, to_opt = pyq.generate_wf(mol, mf, mc=mc)
-    old_parms = wf.parameters
+
+    old_parms = copy.deepcopy(wf.parameters)
     lt = LinearTransform(wf.parameters, to_opt)
 
     # Test serialize parameters
     x0 = lt.serialize_parameters(wf.parameters)
     x0 += np.random.normal(size=x0.shape)
-    wf.parameters = lt.deserialize(x0)
+    for k,it in lt.deserialize(x0).items():
+        assert wf.parameters[k].shape==it.shape
+        wf.parameters[k] = it
+
+    # to_opt is supposed to be false for both of these.
     assert wf.parameters["wf1det_coeff"][0] == old_parms["wf1det_coeff"][0]
     assert np.sum(wf.parameters["wf2bcoeff"][0] - old_parms["wf2bcoeff"][0]) == 0
+    #While this one is supposed to change.
+    assert np.sum(wf.parameters["wf2bcoeff"][1] - old_parms["wf2bcoeff"][1]) != 0
 
     # Test serialize gradients
-    configs = OpenConfigs(np.random.randn(10, 4, 3))
+    configs = pyq.initial_guess(mol, 10)
     wf.recompute(configs)
     pgrad = wf.pgradient()
     pgrad_serial = lt.serialize_gradients(pgrad)
-    assert np.sum(pgrad_serial[:, :3] - pgrad["wf1det_coeff"][:, 1:4]) == 0
 
-
-if __name__ == "__main__":
-    test()
+    #Pgrad should be walkers, configs
+    assert pgrad_serial.shape[1] == x0.shape[0]

--- a/tests/unit/test_wf_derivatives.py
+++ b/tests/unit/test_wf_derivatives.py
@@ -109,8 +109,8 @@ def test_casci_s2(H2_ccecp_casci_s2, epsilon=1e-5):
 def test_manual_slater(H2_ccecp_rhf, epsilon=1e-5):
     mol, mf = H2_ccecp_rhf
 
-    determinants = [ (1.0, [0],[0]),
-                     (-0.2, [1],[1]) ] 
+    determinants = [ (1.0, [[0],[0]]),
+                     (-0.2, [[1],[1]]) ] 
     wf = Slater(mol,mf,determinants=determinants)
     configs = pyq.initial_guess(mol, 10)
     run_tests(wf, configs, epsilon)
@@ -134,22 +134,6 @@ def test_manual_pbcs_fail(H_pbc_sto3g_krks, epsilon=1e-5, nconf=10):
     except:
         pass
 
-def create_determinant(mol, mf, excitations):
-    """
-    excitations should be a list of tuples with 
-    (s,ka,a,ki,i),  
-    s is the spin (0 or 1), 
-    ka, a is the occupied orbital, 
-    and ki, i is the unoccupied orbital.
-    """
-    occupation = [
-        [list(np.nonzero(occ > 0.9)[0]) for occ in mf.mo_occ[s]]
-        for s in range(2)]
-    print(occupation)
-    for s,ka,a,ki,i in excitations:
-        occupation[s][ka].remove(a)
-        occupation[s][ki].append(i)
-    return occupation
     
 
 def test_manual_pbcs_correct(H_pbc_sto3g_kuks, epsilon=1e-5, nconf=10):
@@ -157,13 +141,14 @@ def test_manual_pbcs_correct(H_pbc_sto3g_kuks, epsilon=1e-5, nconf=10):
     This test makes sure that the number of k-points must match the number of k-points 
     in the mf object. 
     """
+    from pyqmc.determinant_tools import create_pbc_determinant
     mol, mf = H_pbc_sto3g_kuks
     supercell = np.identity(3,dtype=int)
     supercell[0,0]=2
     mol = pyq.get_supercell(mol, supercell)
 
-    determinants = [(1.0, create_determinant(mol,mf, [])),
-                     (-0.2, create_determinant(mol, mf, [ (0,0,0,0,1) ] ))
+    determinants = [(1.0, create_pbc_determinant(mol,mf, [])),
+                     (-0.2, create_pbc_determinant(mol, mf, [ (0,0,0,0,1) ] ))
     ]
     wf = Slater(mol, mf, determinants=determinants)
     configs = pyq.initial_guess(mol, 10)

--- a/tests/unit/test_wf_derivatives.py
+++ b/tests/unit/test_wf_derivatives.py
@@ -115,3 +115,56 @@ def test_manual_slater(H2_ccecp_rhf, epsilon=1e-5):
     configs = pyq.initial_guess(mol, 10)
     run_tests(wf, configs, epsilon)
 
+
+def test_manual_pbcs_fail(H_pbc_sto3g_krks, epsilon=1e-5, nconf=10):
+    """
+    This test makes sure that the number of k-points must match the number of k-points 
+    in the mf object. 
+    """
+    mol, mf = H_pbc_sto3g_krks
+    supercell = np.identity(3,dtype=int)
+    supercell[0,0]=2
+    mol = pyq.get_supercell(mol, supercell)
+    try: 
+        determinants =  [ (1.0,    [[0,1],[0,1]],    [[0,1],[0,1]]  ), # first determinant
+                        (-0.2,   [[0,2],[0,1]],     [[0,2],[0,1]] )  # second determinant
+                        ] 
+        wf = Slater(mol, mf, determinants=determinants)
+        raise Exception("Should have failed here")
+    except:
+        pass
+
+def create_determinant(mol, mf, excitations):
+    """
+    excitations should be a list of tuples with 
+    (s,ka,a,ki,i),  
+    s is the spin (0 or 1), 
+    ka, a is the occupied orbital, 
+    and ki, i is the unoccupied orbital.
+    """
+    occupation = [
+        [list(np.nonzero(occ > 0.9)[0]) for occ in mf.mo_occ[s]]
+        for s in range(2)]
+    print(occupation)
+    for s,ka,a,ki,i in excitations:
+        occupation[s][ka].remove(a)
+        occupation[s][ki].append(i)
+    return occupation
+    
+
+def test_manual_pbcs_correct(H_pbc_sto3g_kuks, epsilon=1e-5, nconf=10):
+    """
+    This test makes sure that the number of k-points must match the number of k-points 
+    in the mf object. 
+    """
+    mol, mf = H_pbc_sto3g_kuks
+    supercell = np.identity(3,dtype=int)
+    supercell[0,0]=2
+    mol = pyq.get_supercell(mol, supercell)
+
+    determinants = [(1.0, create_determinant(mol,mf, [])),
+                     (-0.2, create_determinant(mol, mf, [ (0,0,0,0,1) ] ))
+    ]
+    wf = Slater(mol, mf, determinants=determinants)
+    configs = pyq.initial_guess(mol, 10)
+    run_tests(wf, configs, epsilon)

--- a/tests/unit/test_wf_derivatives.py
+++ b/tests/unit/test_wf_derivatives.py
@@ -103,3 +103,15 @@ def test_casci_s2(H2_ccecp_casci_s2, epsilon=1e-5):
     configs = pyq.initial_guess(mol, 10)
     wf = Slater(mol, mf, cisolver, tol=0.0)
     run_tests(wf, configs, epsilon)
+
+
+
+def test_manual_slater(H2_ccecp_rhf, epsilon=1e-5):
+    mol, mf = H2_ccecp_rhf
+
+    determinants = [ (1.0, [0],[0]),
+                     (-0.2, [1],[1]) ] 
+    wf = Slater(mol,mf,determinants=determinants)
+    configs = pyq.initial_guess(mol, 10)
+    run_tests(wf, configs, epsilon)
+


### PR DESCRIPTION
We now allow for a determinants keyword in Slater, which allows the user to construct wave functions by hand. This works for both open and periodic boundary conditions. While testing this, I found a few small bugs in OBDM and TBDM that were fixed. 