### PR TITLE
Fix tbdm dmc

### DIFF
--- a/pyqmc/dmc.py
+++ b/pyqmc/dmc.py
@@ -356,7 +356,6 @@ def rundmc(
         with h5py.File(hdf_file, "r") as hdf:
             stepoffset = hdf["step"][-1] + 1
             configs.load_hdf(hdf)
-            print(configs.configs)
             weights = np.array(hdf["weights"])
             if 'e_trial' not in hdf.keys():
                 raise ValueError("Did not find e_trial in the restart file. This may mean that you are trying to restart from a different version of DMC")

--- a/pyqmc/dmc.py
+++ b/pyqmc/dmc.py
@@ -150,8 +150,6 @@ def dmc_propagate(
                 configs.move(e, newepos, accept)
                 wf.updateinternals(e, newepos, mask=accept)
                 tmove_acceptance += accept/nelec
-            
-
 
         for e in range(nelec):  # drift-diffusion
             newepos, accept, r2 = propose_drift_diffusion(wf, configs, tstep, e)
@@ -358,6 +356,7 @@ def rundmc(
         with h5py.File(hdf_file, "r") as hdf:
             stepoffset = hdf["step"][-1] + 1
             configs.load_hdf(hdf)
+            print(configs.configs)
             weights = np.array(hdf["weights"])
             if 'e_trial' not in hdf.keys():
                 raise ValueError("Did not find e_trial in the restart file. This may mean that you are trying to restart from a different version of DMC")
@@ -371,7 +370,7 @@ def rundmc(
         df, configs = mc.vmc(
             wf,
             configs,
-            accumulators=accumulators,
+            accumulators={ekey[0]:accumulators[ekey[0]]},
             client=client,
             npartitions=npartitions,
             verbose=verbose,
@@ -458,8 +457,5 @@ def estimate_energy(hdf_file, df, ekey):
         en = np.asarray([d[ekey[0]+ekey[1]] for d in df])
         wt = np.asarray([d['weight'] for d in df])
     warmup = int(len(en)/4)
-    return np.average(en[warmup:], weights=wt[warmup:])
+    return np.average(en[warmup:], weights=wt[warmup:]).real
 
-if __name__=="__main__":
-    import run_dmc_shell
-    run_dmc_shell.run_dmc_shell(rundmc, "cyrus_secIIB_with_p",verbose=True)

--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -245,7 +245,6 @@ class PBCOrbitalEvaluatorKpoints:
         """
         mycoords = configs.configs if mask is None else configs.configs[mask]
         mycoords = mycoords.reshape((-1, mycoords.shape[-1]))
-
         # coordinate, dimension
         wrap = configs.wrap if mask is None else configs.wrap[mask]
         wrap = np.dot(wrap, self.S)

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -136,7 +136,6 @@ class Slater:
         (phase,logdet). If the wf is real, phase will be +/- 1."""
 
         nconf, nelec, ndim = configs.configs.shape
-
         aos = self.orbitals.aos("GTOval_sph", configs)
         self._aovals = aos.reshape(-1, nconf, nelec, aos.shape[-1])
         self._dets = []
@@ -221,7 +220,6 @@ class Slater:
             self.parameters["det_coeff"],
             det_array,
         )
-        # curr_val = self.value()
 
         if len(numer.shape) == 2:
             denom = denom[:, gpu.cp.newaxis]

--- a/pyqmc/tbdm.py
+++ b/pyqmc/tbdm.py
@@ -166,8 +166,6 @@ class TBDMAccumulator:
             "value": np.zeros((nconf, self._ijkl.shape[1]), dtype=self.dtype),
             "norm_a": np.zeros((nconf, orb_configs[0].shape[-1])),
             "norm_b": np.zeros((nconf, orb_configs[1].shape[-1])),
-            "acceptance_a": np.mean(aux["acceptance"][0], axis=0),
-            "acceptance_b": np.mean(aux["acceptance"][0], axis=0),
         }
         orb_configs = gpu.cp.asarray([orb_configs[s][:, :, self._ijkl[2 * s]] for s in [0, 1]])
 
@@ -227,21 +225,18 @@ class TBDMAccumulator:
 
     def keys(self):
         return set(
-            ["value", "norm_a", "norm_b", "acceptance_a", "acceptance_b", "ijkl"]
+            ["value", "norm_a", "norm_b"]
         )
 
     def shapes(self):
-        d = {"value": (self._ijkl.shape[1],), "ijkl": self._ijkl.T.shape}
+        d = {"value": (self._ijkl.shape[1],), }
         nmo = self.orbitals.nmo()
         for e, s in zip(["a", "b"], self._spin_sector):
             d["norm_%s" % e] = (nmo[s],)
-            d["acceptance_%s" % e] = ()
         return d
 
     def avg(self, configs, wf):
-        d = {k: np.mean(it, axis=0) for k, it in self(configs, wf).items()}
-        d["ijkl"] = self._ijkl.T
-        return d
+        return {k: np.mean(it, axis=0) for k, it in self(configs, wf).items()}
 
 
 def normalize_tbdm(tbdm, norm_a, norm_b):

--- a/pyqmc/tbdm.py
+++ b/pyqmc/tbdm.py
@@ -46,7 +46,7 @@ class TBDMAccumulator:
         nsweeps=4,
         tstep=0.50,
         warmup=200,
-        naux=500,
+        naux=None,
         ijkl=None,
         kpts=None,
     ):
@@ -55,6 +55,8 @@ class TBDMAccumulator:
         self._tstep = tstep
         self._nsweeps = nsweeps
         self._spin = spin
+        self._naux = naux
+        self._warmup = warmup
 
         if kpts is None:
             self.orbitals = pyqmc.orbitals.MoleculeOrbitalEvaluator(mol, orb_coeff)
@@ -72,17 +74,6 @@ class TBDMAccumulator:
             for s in [0, 1]
         ]
 
-        # Initialization and warmup of configurations
-        nwalkers = int(naux / sum(self._mol.nelec))
-        self._aux_configs = []
-        for spin in [0, 1]:
-            self._aux_configs.append(mc.initial_guess(mol, nwalkers))
-            self._aux_configs[spin].reshape((-1, 1, 3))
-            _, self._aux_configs[spin], _ = obdm.sample_onebody(
-                self._aux_configs[spin], self.orbitals, 0, nsamples=warmup
-            )
-            self._aux_configs[spin] = self._aux_configs[spin][-1]
-
         # Default to full 2rdm if ijkl not specified
         if ijkl is None:
             norb_up = orb_coeff[0].shape[1]
@@ -95,6 +86,20 @@ class TBDMAccumulator:
                 for l in range(norb_down)
             ]
         self._ijkl = np.array(ijkl).T
+        self._warmed_up = False
+
+    def warm_up(self, naux):
+        # Initialization and warmup of configurations
+        nwalkers = int(naux / sum(self._mol.nelec))+1
+        self._aux_configs = []
+        for spin in [0, 1]:
+            self._aux_configs.append(mc.initial_guess(self._mol, nwalkers))
+            self._aux_configs[spin].reshape((-1, 1, 3))
+            self._aux_configs[spin].resample(range(naux))
+            _, self._aux_configs[spin], _ = obdm.sample_onebody(
+                self._aux_configs[spin], self.orbitals, 0, nsamples=self._warmup
+            )
+            self._aux_configs[spin] = self._aux_configs[spin][-1]
 
     def get_configurations(self, nconf):
         """
@@ -109,8 +114,6 @@ class TBDMAccumulator:
             orbs: [nsweeps, conf, norb]: orbital values
             configs: [nsweeps] Configuration object with nconf configurations of 1 electron
             acceptance: [nsweeps, naux] acceptance probability for each auxilliary walker
-
-        TODO: Should we just resize the configurations to nconf instead of taking naux as an input?
         """
         configs = []
         assignments = []
@@ -151,6 +154,11 @@ class TBDMAccumulator:
         """
 
         nconf = configs.configs.shape[0]
+        if not self._warmed_up:
+            naux = nconf if self._naux is None else self._naux
+            self.warm_up(naux)
+            self._warmed_up = True
+
         aux = self.get_configurations(nconf)
 
         # Evaluate orbital values for the primary samples


### PR DESCRIPTION
DMC did not work with TBDM as written because `__call__` should return only quantities _per_ walker, and it was returning acceptances that were not per walker. Also fix a performance bug where warmup was done in `__init__` which caused serious lags when running in parallel.