### PR TITLE
use grad2 in node_regr

### DIFF
--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -128,18 +128,14 @@ class PGradTransform:
         self.transform = transform
         self.nodal_cutoff = nodal_cutoff
 
-    def _node_regr(self, configs, wf):
+    def _node_regr(self, configs, grad2):
         """
         Return true if a given configuration is within nodal_cutoff
         of the node
         Also return the regularization polynomial if true,
         f = a * r ** 2 + b * r ** 4 + c * r ** 3
         """
-        ne = configs.configs.shape[1]
-        d2 = 0.0
-        for e in range(ne):
-            d2 += np.sum(np.abs(wf.gradient(e, configs.electron(e))) ** 2, axis=0)
-        r = 1.0 / d2
+        r = 1.0 / grad2
         mask = r < self.nodal_cutoff ** 2
 
         c = 7.0 / (self.nodal_cutoff ** 6)
@@ -157,7 +153,7 @@ class PGradTransform:
         energy = d["total"]
         dp = self.transform.serialize_gradients(pgrad)
 
-        node_cut, f = self._node_regr(configs, wf)
+        node_cut, f = self._node_regr(configs, d["grad2"])
         dp_regularized = dp * f[:, np.newaxis]
 
         d["dpH"] = np.einsum("i,ij->ij", energy, dp_regularized)
@@ -181,7 +177,7 @@ class PGradTransform:
         energy = den["total"]
         dp = self.transform.serialize_gradients(pgrad)
 
-        node_cut, f = self._node_regr(configs, wf)
+        node_cut, f = self._node_regr(configs, den["grad2"])
 
         dp_regularized = dp * f[:, np.newaxis]
 

--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -133,7 +133,7 @@ class PGradTransform:
         Return true if a given configuration is within nodal_cutoff
         of the node
         Also return the regularization polynomial if true,
-        f = a * r ** 2 + b * r ** 4 + c * r ** 3
+        f = a * r ** 2 + b * r ** 4 + c * r ** 6
         """
         r = 1.0 / grad2
         mask = r < self.nodal_cutoff ** 2

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -50,17 +50,10 @@ def collect_overlap_data(wfs, configs, pgrad):
     ) / len(ref)
 
     dppsi = pgrad.transform.serialize_gradients(wfs[-1].pgradient())
-    d2 = 0.0
-    ne = configs.configs.shape[1]
-    for e in range(ne):
-        d2 += np.sum(np.abs(wfs[-1].gradient(e, configs.electron(e))) ** 2, axis=0)
-    node_cut, f = pgrad._node_regr(configs, d2)
-    dppsi_regularized = dppsi * f[:, np.newaxis]
-
     save_dat["overlap_gradient"] = (
         np.einsum(
             "km,k,jk->jm",  # shape (wf, param)
-            dppsi_regularized.conj(),
+            dppsi,
             normalized_values[-1].conj(),
             normalized_values / denominator,
         )

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -50,7 +50,11 @@ def collect_overlap_data(wfs, configs, pgrad):
     ) / len(ref)
 
     dppsi = pgrad.transform.serialize_gradients(wfs[-1].pgradient())
-    node_cut, f = pgrad._node_regr(configs, wfs[-1])
+    d2 = 0.0
+    ne = configs.configs.shape[1]
+    for e in range(ne):
+        d2 += np.sum(np.abs(wfs[-1].gradient(e, configs.electron(e))) ** 2, axis=0)
+    node_cut, f = pgrad._node_regr(configs, d2)
     dppsi_regularized = dppsi * f[:, np.newaxis]
 
     save_dat["overlap_gradient"] = (


### PR DESCRIPTION
in _node_regr we have the line d2 += np.sum(np.abs(wf.gradient(e, configs.electron(e))) ** 2, axis=0). this is the same quantity grad2 that is computed by energy.kinetic after the recent DMC upgrade. 

This change reuses grad2 instead of computing all the gradients again.

optimize_ortho.collect_overlap_data calls pgrad._node_regr directly, as well as callign pgrad.avg. grad2 is being computed twice here, but I haven't figured out how to reuse it, so it's recomputed in collect_overlap_data for now.