### PR TITLE
Enable restarts from different files

### DIFF
--- a/examples/h2_restarts_example.py
+++ b/examples/h2_restarts_example.py
@@ -1,0 +1,88 @@
+# How to use restarts with PyQMC
+from pyscf import gto, scf
+import pyqmc.recipes
+
+
+def run_mf():
+    mol = gto.M(
+        atom="H 0. 0. 0.; H 0. 0. 1.4", ecp="ccecp", basis="ccecp-ccpvtz", unit="bohr"
+    )
+    mf = scf.RHF(mol)
+    mf.chkfile = "h2.chk"
+    mf.kernel()
+    return mf.chkfile
+
+
+def run_restarts(ntimes=5):
+    chkfile = run_mf()
+    common_args = dict(
+        nconfig=100,
+        verbose=True,
+        jastrow_kws=dict(na=2),
+    )
+    for i in range(ntimes):
+        pyqmc.recipes.OPTIMIZE(
+            chkfile,
+            f"h2_opt{i}.hdf",
+            starting_wf=f"h2_opt{i-1}.hdf" if i > 0 else None,
+            slater_kws=dict(optimize_orbitals=True, optimize_zeros=False),
+            max_iterations=2,
+            **common_args,
+        )
+    for i in range(ntimes):
+        print(i)
+        pyqmc.recipes.VMC(
+            chkfile,
+            f"h2_vmc{i}.hdf",
+            starting_wf=f"h2_opt{ntimes-1}.hdf",
+            restart_from=f"h2_vmc{i-1}.hdf" if i > 0 else None,
+            **common_args,
+            nblocks=2,
+        )
+    for i in range(ntimes):
+        print(i)
+        pyqmc.recipes.DMC(
+            chkfile,
+            f"h2_dmc{i}.hdf",
+            starting_wf=f"h2_opt{ntimes-1}.hdf",
+            restart_from=f"h2_dmc{i-1}.hdf" if i > 0 else None,
+            **common_args,
+            nsteps=10,
+        )
+
+
+def extend_hdf(f, source):
+    for k, it in source.items():
+        if k in ["wf", "configs", "weights"]:
+            continue
+        currshape = f[k].shape
+        f[k].resize((currshape[0] + it.shape[0], *currshape[1:]))
+        f[k][currshape[0] :] = it
+
+
+def copy_configs(f, source):
+    for k in ["configs", "weights"]:
+        if k in source.keys():
+            f[k][...] = source[k]
+
+
+def gather(sourcefile, nfiles=5):
+    import h5py
+    import shutil
+
+    allfile = sourcefile.format("_all")
+    shutil.copyfile(sourcefile.format(0), allfile)
+    with h5py.File(allfile, "a") as hdf:
+        for i in range(1, nfiles):
+            with h5py.File(sourcefile.format(i), "r") as source:
+                extend_hdf(hdf, source)
+                if i == nfiles - 1:
+                    copy_configs(hdf, source)
+
+
+if __name__ == "__main__":
+    n = 5
+    run_restarts(ntimes=n)
+    gather("h2_opt{0}.hdf", nfiles=n)
+    gather("h2_vmc{0}.hdf", nfiles=n)
+    gather("h2_dmc{0}.hdf", nfiles=n)

--- a/examples/h2_restarts_example.py
+++ b/examples/h2_restarts_example.py
@@ -24,7 +24,7 @@ def run_restarts(ntimes=5):
         pyqmc.recipes.OPTIMIZE(
             chkfile,
             f"h2_opt{i}.hdf",
-            starting_wf=f"h2_opt{i-1}.hdf" if i > 0 else None,
+            load_parameters=f"h2_opt{i-1}.hdf" if i > 0 else None,
             slater_kws=dict(optimize_orbitals=True, optimize_zeros=False),
             max_iterations=2,
             **common_args,
@@ -34,7 +34,7 @@ def run_restarts(ntimes=5):
         pyqmc.recipes.VMC(
             chkfile,
             f"h2_vmc{i}.hdf",
-            starting_wf=f"h2_opt{ntimes-1}.hdf",
+            load_parameters=f"h2_opt{ntimes-1}.hdf",
             restart_from=f"h2_vmc{i-1}.hdf" if i > 0 else None,
             **common_args,
             nblocks=2,
@@ -44,7 +44,7 @@ def run_restarts(ntimes=5):
         pyqmc.recipes.DMC(
             chkfile,
             f"h2_dmc{i}.hdf",
-            starting_wf=f"h2_opt{ntimes-1}.hdf",
+            load_parameters=f"h2_opt{ntimes-1}.hdf",
             restart_from=f"h2_dmc{i-1}.hdf" if i > 0 else None,
             **common_args,
             nsteps=10,

--- a/pyqmc/dmc.py
+++ b/pyqmc/dmc.py
@@ -324,7 +324,7 @@ def rundmc(
     ekey=("energy", "total"),
     feedback=1.0,
     hdf_file=None,
-    restart_from=None,
+    continue_from=None,
     client=None,
     npartitions=None,
     **kwargs,
@@ -351,10 +351,16 @@ def rundmc(
 
     """
     # Restart from HDF file
-    if restart_from is None:
-        restart_from = hdf_file
-    if restart_from is not None and os.path.isfile(restart_from):
-        with h5py.File(restart_from, "r") as hdf:
+    if continue_from is None:
+        continue_from = hdf_file
+    elif hdf_file is not None and os.path.isfile(hdf_file):
+        raise RuntimeError(
+            "continue_from is not None but hdf_file={0} already exists! Delete or rename {0} and try again.".format(
+                hdf_file
+            )
+        )
+    if continue_from is not None and os.path.isfile(continue_from):
+        with h5py.File(continue_from, "r") as hdf:
             stepoffset = hdf["step"][-1] + 1
             configs.load_hdf(hdf)
             weights = np.array(hdf["weights"])
@@ -366,7 +372,7 @@ def rundmc(
             e_est = hdf["e_est"][-1]
             esigma = hdf["esigma"][-1]
             if verbose:
-                print("Restarted calculation")
+                print(f"Restarting calculation {continue_from} from step {stepoffset}")
     else:
         warmup = 2
         df, configs = mc.vmc(

--- a/pyqmc/dmc.py
+++ b/pyqmc/dmc.py
@@ -353,6 +353,8 @@ def rundmc(
     # Restart from HDF file
     if continue_from is None:
         continue_from = hdf_file
+    elif not os.path.isfile(continue_from):
+        raise RuntimeError("cannot continue from {0}; the file does not exist!")
     elif hdf_file is not None and os.path.isfile(hdf_file):
         raise RuntimeError(
             "continue_from is not None but hdf_file={0} already exists! Delete or rename {0} and try again.".format(

--- a/pyqmc/dmc.py
+++ b/pyqmc/dmc.py
@@ -324,6 +324,7 @@ def rundmc(
     ekey=("energy", "total"),
     feedback=1.0,
     hdf_file=None,
+    restart_from=None,
     client=None,
     npartitions=None,
     **kwargs,
@@ -350,8 +351,10 @@ def rundmc(
 
     """
     # Restart from HDF file
-    if hdf_file is not None and os.path.isfile(hdf_file):
-        with h5py.File(hdf_file, "r") as hdf:
+    if restart_from is None:
+        restart_from = hdf_file
+    if restart_from is not None and os.path.isfile(restart_from):
+        with h5py.File(restart_from, "r") as hdf:
             stepoffset = hdf["step"][-1] + 1
             configs.load_hdf(hdf)
             weights = np.array(hdf["weights"])

--- a/pyqmc/mc.py
+++ b/pyqmc/mc.py
@@ -165,7 +165,7 @@ def vmc(
     verbose=False,
     stepoffset=0,
     hdf_file=None,
-    restart_from=None,
+    continue_from=None,
     client=None,
     npartitions=None,
 ):
@@ -202,15 +202,23 @@ def vmc(
             print("WARNING: running VMC with no accumulators")
 
     # Restart
-    if restart_from is None:
-        restart_from = hdf_file
-    if restart_from is not None and os.path.isfile(restart_from):
-        with h5py.File(restart_from, "r") as hdf:
+    if continue_from is None:
+        continue_from = hdf_file
+    elif hdf_file is not None and os.path.isfile(hdf_file):
+        raise RuntimeError(
+            "continue_from is not None but hdf_file={0} already exists! Delete or rename {0} and try again.".format(
+                hdf_file
+            )
+        )
+    if continue_from is not None and os.path.isfile(continue_from):
+        with h5py.File(continue_from, "r") as hdf:
             if "configs" in hdf.keys():
                 stepoffset = hdf["block"][-1] + 1
                 configs.load_hdf(hdf)
                 if verbose:
-                    print("Restarting calculation from step", stepoffset)
+                    print(
+                        f"Restarting calculation {continue_from} from step {stepoffset}"
+                    )
 
     df = []
 

--- a/pyqmc/mc.py
+++ b/pyqmc/mc.py
@@ -165,6 +165,7 @@ def vmc(
     verbose=False,
     stepoffset=0,
     hdf_file=None,
+    restart_from=None,
     client=None,
     npartitions=None,
 ):
@@ -201,8 +202,10 @@ def vmc(
             print("WARNING: running VMC with no accumulators")
 
     # Restart
-    if hdf_file is not None:
-        with h5py.File(hdf_file, "a") as hdf:
+    if restart_from is None:
+        restart_from = hdf_file
+    if restart_from is not None and os.path.isfile(restart_from):
+        with h5py.File(restart_from, "r") as hdf:
             if "configs" in hdf.keys():
                 stepoffset = hdf["block"][-1] + 1
                 configs.load_hdf(hdf)

--- a/pyqmc/mc.py
+++ b/pyqmc/mc.py
@@ -204,6 +204,8 @@ def vmc(
     # Restart
     if continue_from is None:
         continue_from = hdf_file
+    elif not os.path.isfile(continue_from):
+        raise RuntimeError("cannot continue from {0}; the file does not exist!")
     elif hdf_file is not None and os.path.isfile(hdf_file):
         raise RuntimeError(
             "continue_from is not None but hdf_file={0} already exists! Delete or rename {0} and try again.".format(

--- a/pyqmc/recipes.py
+++ b/pyqmc/recipes.py
@@ -13,6 +13,7 @@ import scipy.stats
 import pandas as pd
 import copy
 import pyqmc.accumulators
+import os
 
 
 def OPTIMIZE(
@@ -21,19 +22,25 @@ def OPTIMIZE(
     anchors=None,
     nconfig=1000,
     ci_checkfile=None,
-    starting_wf=None,
+    load_parameters=None,
     S=None,
     jastrow_kws=None,
     slater_kws=None,
     **linemin_kws,
 ):
     linemin_kws["hdf_file"] = output
+    if load_parameters is not None and output is not None and os.path.isfile(output):
+        raise RuntimeError(
+            "load_parameters is not None and output={0} already exists! Delete or rename {0} and try again.".format(
+                output
+            )
+        )
     wf, configs, acc = initialize_qmc_objects(
         dft_checkfile,
         opt_wf=True,
         nconfig=nconfig,
         ci_checkfile=ci_checkfile,
-        starting_wf=starting_wf,
+        load_parameters=load_parameters,
         S=S,
         jastrow_kws=jastrow_kws,
         slater_kws=slater_kws,
@@ -76,7 +83,7 @@ def VMC(
     output,
     nconfig=1000,
     ci_checkfile=None,
-    starting_wf=None,
+    load_parameters=None,
     S=None,
     jastrow_kws=None,
     slater_kws=None,
@@ -88,7 +95,7 @@ def VMC(
         dft_checkfile,
         nconfig=nconfig,
         ci_checkfile=ci_checkfile,
-        starting_wf=starting_wf,
+        load_parameters=load_parameters,
         S=S,
         jastrow_kws=jastrow_kws,
         slater_kws=slater_kws,
@@ -102,7 +109,7 @@ def DMC(
     output,
     nconfig=1000,
     ci_checkfile=None,
-    starting_wf=None,
+    load_parameters=None,
     S=None,
     jastrow_kws=None,
     slater_kws=None,
@@ -114,7 +121,7 @@ def DMC(
         dft_checkfile,
         nconfig=nconfig,
         ci_checkfile=ci_checkfile,
-        starting_wf=starting_wf,
+        load_parameters=load_parameters,
         S=S,
         jastrow_kws=jastrow_kws,
         slater_kws=slater_kws,
@@ -126,7 +133,7 @@ def DMC(
 def initialize_qmc_objects(
     dft_checkfile,
     nconfig=1000,
-    starting_wf=None,
+    load_parameters=None,
     ci_checkfile=None,
     S=None,
     jastrow_kws=None,
@@ -148,8 +155,8 @@ def initialize_qmc_objects(
     wf, to_opt = wftools.generate_wf(
         mol, mf, mc=mc, jastrow_kws=jastrow_kws, slater_kws=slater_kws
     )
-    if starting_wf is not None:
-        wftools.read_wf(wf, starting_wf)
+    if load_parameters is not None:
+        wftools.read_wf(wf, load_parameters)
 
     configs = pyqmc.mc.initial_guess(mol, nconfig)
     if opt_wf:

--- a/pyqmc/recipes.py
+++ b/pyqmc/recipes.py
@@ -21,7 +21,7 @@ def OPTIMIZE(
     anchors=None,
     nconfig=1000,
     ci_checkfile=None,
-    start_from=None,
+    starting_wf=None,
     S=None,
     jastrow_kws=None,
     slater_kws=None,
@@ -33,7 +33,7 @@ def OPTIMIZE(
         opt_wf=True,
         nconfig=nconfig,
         ci_checkfile=ci_checkfile,
-        start_from=start_from,
+        starting_wf=starting_wf,
         S=S,
         jastrow_kws=jastrow_kws,
         slater_kws=slater_kws,
@@ -76,7 +76,7 @@ def VMC(
     output,
     nconfig=1000,
     ci_checkfile=None,
-    start_from=None,
+    starting_wf=None,
     S=None,
     jastrow_kws=None,
     slater_kws=None,
@@ -88,7 +88,7 @@ def VMC(
         dft_checkfile,
         nconfig=nconfig,
         ci_checkfile=ci_checkfile,
-        start_from=start_from,
+        starting_wf=starting_wf,
         S=S,
         jastrow_kws=jastrow_kws,
         slater_kws=slater_kws,
@@ -102,7 +102,7 @@ def DMC(
     output,
     nconfig=1000,
     ci_checkfile=None,
-    start_from=None,
+    starting_wf=None,
     S=None,
     jastrow_kws=None,
     slater_kws=None,
@@ -114,7 +114,7 @@ def DMC(
         dft_checkfile,
         nconfig=nconfig,
         ci_checkfile=ci_checkfile,
-        start_from=start_from,
+        starting_wf=starting_wf,
         S=S,
         jastrow_kws=jastrow_kws,
         slater_kws=slater_kws,
@@ -126,7 +126,7 @@ def DMC(
 def initialize_qmc_objects(
     dft_checkfile,
     nconfig=1000,
-    start_from=None,
+    starting_wf=None,
     ci_checkfile=None,
     S=None,
     jastrow_kws=None,
@@ -148,8 +148,8 @@ def initialize_qmc_objects(
     wf, to_opt = wftools.generate_wf(
         mol, mf, mc=mc, jastrow_kws=jastrow_kws, slater_kws=slater_kws
     )
-    if start_from is not None:
-        wftools.read_wf(wf, start_from)
+    if starting_wf is not None:
+        wftools.read_wf(wf, starting_wf)
 
     configs = pyqmc.mc.initial_guess(mol, nconfig)
     if opt_wf:


### PR DESCRIPTION
E.g. restart vmc from `vmc1.hdf` and continue recording in `vmc2.hdf`.

In the recipes, I changed all `start_from` keywords to `starting_wf` to avoid confusion with the previous version. vmc() and rundmc() take kwarg `restart_from`, which is the filename of the run to continue from.

I also added an example to demonstrate the new option.