### PR TITLE
shorten warmup time before optimization

### DIFF
--- a/pyqmc/linemin.py
+++ b/pyqmc/linemin.py
@@ -97,8 +97,8 @@ def line_minimization(
     coords,
     pgrad_acc,
     steprange=0.2,
-    warmup=0,
     max_iterations=30,
+    warmup_options=None,
     vmcoptions=None,
     lmoptions=None,
     update=sr_update,
@@ -134,6 +134,10 @@ def line_minimization(
         lmoptions = {}
     if update_kws is None:
         update_kws = {}
+    if warmup_options is None:
+        warmup_options = dict(nblocks=1, nsteps_per_block=10, verbose=verbose)
+    if "tstep" not in warmup_options and "tstep" in vmcoptions:
+        warmup_options["tstep"] = vmcoptions["tstep"]
 
     # Restart
     iteration_offset = 0
@@ -188,7 +192,7 @@ def line_minimization(
         accumulators={},
         client=client,
         npartitions=npartitions,
-        **vmcoptions
+        **warmup_options
     )
     if verbose:
         print("finished warmup", flush=True)

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -389,7 +389,7 @@ def optimize_orthogonal(
     forcing=None,
     tstep=0.1,
     max_iterations=30,
-    warmup=5,
+    warmup=1,
     warmup_options=None,
     Ntarget=0.5,
     max_step=10.0,
@@ -525,7 +525,9 @@ def optimize_orthogonal(
 
     # warm up to equilibrate the configurations before running optimization
     if warmup_options is None:
-        warmup_options = {}
+        warmup_options = dict(nblocks=1, nsteps=10)
+    if "tstep" not in warmup_options and "tstep" in sample_options:
+        warmup_options["tstep"] = sample_options["tstep"]
 
     data, coords = mc.vmc(
         wfs[-1],


### PR DESCRIPTION
in linemin:
1. use kwarg `warmup_options` for warmup parameters (like in optimize_orthogonal) instead of using vmcoptions. Default `warmup_options` is to warm up for 10 steps (instead of 100) with the same tstep as vmcoptions.
2. remove kwarg `warmup` from linemin since it isn't being used.

in optimize_orthogonal: 
1. change default `warmup_options` to warm up for 10 steps (instead of 100) and use same tstep as `sample_options`
2. change default `warmup` (steps to throw away each iteration) from 5 to 1.