### PR TITLE
Nonorthogonal

### DIFF
--- a/pyqmc/distance.py
+++ b/pyqmc/distance.py
@@ -86,9 +86,9 @@ class MinimalImageDistance(RawDistance):
             self.dist_i = self.diagonal_dist_i
         else:
             orthogonal = (
-                np.dot(latvec[0], latvec[1]) < ortho_tol
-                and np.dot(latvec[1], latvec[2]) < ortho_tol
-                and np.dot(latvec[2], latvec[0]) < ortho_tol
+                np.abs(np.dot(latvec[0], latvec[1])) < ortho_tol
+                and np.abs(np.dot(latvec[1], latvec[2])) < ortho_tol
+                and np.abs(np.dot(latvec[2], latvec[0])) < ortho_tol
             )
             if orthogonal:
                 self.dist_i = self.orthogonal_dist_i

--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -114,10 +114,10 @@ class Ewald:
         :parameter int ewald_gmax: max number of reciprocal lattice vectors to check away from 0
         """
         cellvolume = np.linalg.det(self.latvec)
-        recvec = np.linalg.inv(self.latvec)
+        recvec = np.linalg.inv(self.latvec).T
 
         # Determine alpha
-        smallestheight = np.amin(1 / np.linalg.norm(recvec.T, axis=1))
+        smallestheight = np.amin(1 / np.linalg.norm(recvec, axis=1))
         self.alpha = 5.0 / smallestheight
 
         # Determine G points to include in reciprocal Ewald sum


### PR DESCRIPTION
fix two bugs in non-orthogonal unit cells: 
1. distance object recognizes non-orthogonal cell with negative dot products
2. ewald computes gpoints correctly (transposed reciprocal matrix)