### PR TITLE
Made some small fixes on examples using recipes

### DIFF
--- a/examples/he_recipe.py
+++ b/examples/he_recipe.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
         accumulators={"rdm1": True},
         jastrow_kws=jastrow_kws,
         slater_kws=slater_kws,
-        vmc_kws={"nblocks": 40},
+        **{"nblocks": 40},
     )
 
     pyqmc.recipes.DMC(
@@ -34,5 +34,5 @@ if __name__ == "__main__":
         accumulators={"rdm1": True},
         jastrow_kws=jastrow_kws,
         slater_kws=slater_kws,
-        dmc_kws={"nsteps": 4000, "tstep": 0.02},
+        **{"nsteps": 4000, "tstep": 0.02},
     )

--- a/examples/he_recipe_mpi.py
+++ b/examples/he_recipe_mpi.py
@@ -33,9 +33,9 @@ if __name__ == "__main__":
             accumulators={"rdm1": True},
             jastrow_kws=jastrow_kws,
             slater_kws=slater_kws,
-            vmc_kws={"nblocks": 40},
             client=client,
             npartitions=npartitions,
+            **{"nblocks": 40},
         )
 
         pyqmc.recipes.DMC(
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             accumulators={"rdm1": True},
             jastrow_kws=jastrow_kws,
             slater_kws=slater_kws,
-            dmc_kws={"nsteps": 4000, "tstep": 0.02},
             client=client,
             npartitions=npartitions,
+            **{"nsteps": 4000, "tstep": 0.02},
         )

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -104,7 +104,7 @@
     }
    ],
    "source": [
-    "pyqmc.recipes.OPTIMIZE(\"h2o.hdf5\",\"h2o_sj_200.hdf5\",nconfig=200, linemin_kws={'max_iterations':10})"
+    "pyqmc.recipes.OPTIMIZE(\"h2o.hdf5\",\"h2o_sj_200.hdf5\",nconfig=200, **{'max_iterations':10,'verbose':True})"
    ]
   },
   {
@@ -113,7 +113,7 @@
    "source": [
     "* Since we want to start from the previous optimization, we use the `start_from` command in OPTIMIZE.\n",
     "\n",
-    "* Setting a keyword for the line minimization algorithm `linemin_kws` so it only runs for 10 iterations, just to keep the computation low for this example."
+    "* Using `**kwargs` to pass a keyword to the line minimization algorithm so it only runs for 10 iterations, just to keep the computation low for this example."
    ]
   },
   {
@@ -163,7 +163,7 @@
     }
    ],
    "source": [
-    "pyqmc.recipes.OPTIMIZE(\"h2o.hdf5\",\"h2o_sj_800.hdf5\", start_from=\"h2o_sj_200.hdf5\", nconfig=800, linemin_kws={'max_iterations':10})"
+    "pyqmc.recipes.OPTIMIZE(\"h2o.hdf5\",\"h2o_sj_800.hdf5\", start_from=\"h2o_sj_200.hdf5\", nconfig=800, **{'max_iterations':10,'verbose':True})"
    ]
   },
   {
@@ -199,7 +199,7 @@
     "import seaborn as sns\n",
     "df = pd.concat([pyqmc.recipes.read_opt(f\"h2o_sj_{n}.hdf5\") for n in [200,800]])\n",
     "g = sns.FacetGrid(hue='fname',data=df)\n",
-    "g.map(plt.errorbar,'it','en','err', marker='o')\n",
+    "g.map(plt.errorbar,'iteration','energy','error', marker='o')\n",
     "g.add_legend()"
    ]
   },
@@ -221,7 +221,7 @@
    ],
    "source": [
     "for n in [200,800]:\n",
-    "    pyqmc.recipes.VMC(\"h2o.hdf5\",f\"h2o_sj_vmc_{n}.hdf5\", start_from=f\"h2o_sj_{n}.hdf5\", vmc_kws=dict(nblocks=100))"
+    "    pyqmc.recipes.VMC(\"h2o.hdf5\",f\"h2o_sj_vmc_{n}.hdf5\", start_from=f\"h2o_sj_{n}.hdf5\", **dict(nblocks=100,verbose=True))"
    ]
   },
   {
@@ -482,7 +482,7 @@
     }
    ],
    "source": [
-    "pyqmc.recipes.DMC(\"h2o.hdf5\",f\"h2o_sj_dmc_800.hdf5\", start_from=f\"h2o_sj_800.hdf5\")\n"
+    "pyqmc.recipes.DMC(\"h2o.hdf5\",f\"h2o_sj_dmc_800.hdf5\", start_from=f\"h2o_sj_800.hdf5\",**{'verbose':True})\n"
    ]
   },
   {

--- a/pyqmc/recipes.py
+++ b/pyqmc/recipes.py
@@ -179,7 +179,7 @@ def read_mc_output(fname, warmup=5, reblock=16):
     with h5py.File(fname) as f:
         for k in f.keys():
             if "energy" in k:
-                vals = pyqmc.reblock.avg_reblock(f[k][warmup:], reblock)
+                vals = pyqmc.reblock.reblock(f[k][warmup:], reblock)
                 ret[k] = np.mean(vals)
                 ret[k + "_err"] = scipy.stats.sem(vals)
     return ret


### PR DESCRIPTION
Following commit e59ae4c415e35c6d039ea9e28387f7c65bde780d where recipes were modified (kwargs passed instead of dictionary), the He examples and tutorial needed modification.

Also fixed read_mc_output() in recipes.py which was using the unknown method pyqmc.reblock.avg_reblock().