### PR TITLE
use new stable_fit3 in linemin

### DIFF
--- a/pyqmc/linemin.py
+++ b/pyqmc/linemin.py
@@ -64,8 +64,6 @@ def stable_fit(xfit, yfit, tolerance=1e-2):
     a = np.argmin(yfit)
     pq, relative_errq = polyfit_relative(xfit, yfit, 2)
     pl, relative_errl = polyfit_relative(xfit, yfit, 1)
-    if 0. not in xfit:
-        print("Warning: potential instability in optimization; 0 not in xfit \n{xfit}")
 
     if relative_errl / relative_errq < 2:  # If a linear fit is about as good..
         if pl[0] < 0:

--- a/pyqmc/linemin.py
+++ b/pyqmc/linemin.py
@@ -47,24 +47,33 @@ def polyfit_relative(xfit, yfit, degree):
     return p, relative_error
 
 
-def stable_fit3(xfit, yfit, tolerance=1e-2):
-    """Try to fit to a quadratic. If the fit is not good,
-    then just take the lowest value of yfit
+def stable_fit(xfit, yfit, tolerance=1e-2):
+    """Fit a line and quadratic to xfit and yfit. 
+    1. If the linear fit is as good as the quadriatic, choose the lower endpoint.
+    2. If the curvature is positive, estimate the minimum x value.
+    3. If the lowest yfit is less than the new guess, use that xfit instead.
+
+    :parameter list xfit: scalar step sizes along line
+    :parameter list yfit: estimated energies at xfit points
+    :parameter float tolerance: how good the quadratic fit needs to be
+    :returns: estimated x-value of minimum
+    :rtype: float
     """
     steprange = np.max(xfit)
     minstep = np.min(xfit)
     a = np.argmin(yfit)
     pq, relative_errq = polyfit_relative(xfit, yfit, 2)
     pl, relative_errl = polyfit_relative(xfit, yfit, 1)
+    if 0. not in xfit:
+        print("Warning: potential instability in optimization; 0 not in xfit \n{xfit}")
 
-    print("relative errors in fit", relative_errq, relative_errl)
     if relative_errl / relative_errq < 2:  # If a linear fit is about as good..
         if pl[0] < 0:
             est_min = steprange
         else:
             est_min = minstep
         out_y = np.polyval(pl, est_min)
-    elif relative_errq < tolerance and pq[0] > 0:
+    elif relative_errq < tolerance and pq[0] > 0: # If quadratic fit is good
         est_min = -pq[1] / (2 * pq[0])
         if est_min > steprange:
             est_min = steprange
@@ -74,53 +83,8 @@ def stable_fit3(xfit, yfit, tolerance=1e-2):
     else:
         est_min = xfit[a]
         out_y = yfit[a]
-    if out_y > yfit[a]:
+    if out_y > yfit[a]: # If min(yfit) has a lower energy than the guess, use it instead
         est_min = xfit[a]
-    return est_min
-
-
-def stable_fit2(xfit, yfit, tolerance=1e-2):
-    """Try to fit to a quadratic. If the fit is not good,
-    then just take the lowest value of yfit
-    """
-    steprange = np.max(xfit)
-    minstep = np.min(xfit)
-    pq, relative_errq = polyfit_relative(xfit, yfit, 2)
-    pl, relative_errl = polyfit_relative(xfit, yfit, 1)
-
-    print("relative errors in fit", relative_errq, relative_errl)
-    if relative_errl / relative_errq < 2:  # If a linear fit is about as good..
-        if pl[0] < 0:
-            return steprange
-        else:
-            return minstep
-    elif relative_errq < tolerance and pq[0] > 0:
-        est_min = -pq[1] / (2 * pq[0])
-        if est_min > steprange:
-            est_min = steprange
-        if est_min < minstep:
-            est_min = minstep
-        return est_min
-    else:
-        return xfit[np.argmin(yfit)]
-
-
-def stable_fit(xfit, yfit):
-    p = np.polyfit(xfit, yfit, 2)
-    steprange = np.max(xfit)
-    minstep = np.min(xfit)
-    est_min = -p[1] / (2 * p[0])
-    if est_min > steprange and p[0] > 0:  # minimum past the search radius
-        est_min = steprange
-    if est_min < minstep and p[0] > 0:  # mimimum behind the search radius
-        est_min = minstep
-    if p[0] < 0:
-        plin = np.polyfit(xfit, yfit, 1)
-        if plin[0] < 0:
-            est_min = steprange
-        if plin[0] > 0:
-            est_min = minstep
-    # print("estimated minimum adjusted", est_min, flush=True)
     return est_min
 
 
@@ -268,7 +232,7 @@ def line_minimization(
         en = np.real(np.mean(stepsdata["total"] * stepsdata["weight"], axis=1))
         yfit.extend(en)
         xfit.extend(steps)
-        est_min = stable_fit3(xfit, yfit)
+        est_min = stable_fit(xfit, yfit)
         x0 += update(pgrad, Sij, est_min, **update_kws)
         step_data["tau"] = xfit
         step_data["yfit"] = yfit

--- a/pyqmc/linemin.py
+++ b/pyqmc/linemin.py
@@ -47,6 +47,38 @@ def polyfit_relative(xfit, yfit, degree):
     return p, relative_error
 
 
+def stable_fit3(xfit, yfit, tolerance=1e-2):
+    """Try to fit to a quadratic. If the fit is not good,
+    then just take the lowest value of yfit
+    """
+    steprange = np.max(xfit)
+    minstep = np.min(xfit)
+    a = np.argmin(yfit)
+    pq, relative_errq = polyfit_relative(xfit, yfit, 2)
+    pl, relative_errl = polyfit_relative(xfit, yfit, 1)
+
+    print("relative errors in fit", relative_errq, relative_errl)
+    if relative_errl / relative_errq < 2:  # If a linear fit is about as good..
+        if pl[0] < 0:
+            est_min = steprange
+        else:
+            est_min = minstep
+        out_y = np.polyval(pl, est_min)
+    elif relative_errq < tolerance and pq[0] > 0:
+        est_min = -pq[1] / (2 * pq[0])
+        if est_min > steprange:
+            est_min = steprange
+        if est_min < minstep:
+            est_min = minstep
+        out_y = np.polyval(pq, est_min)
+    else:
+        est_min = xfit[a]
+        out_y = yfit[a]
+    if out_y > yfit[a]:
+        est_min = xfit[a]
+    return est_min
+
+
 def stable_fit2(xfit, yfit, tolerance=1e-2):
     """Try to fit to a quadratic. If the fit is not good,
     then just take the lowest value of yfit
@@ -138,6 +170,7 @@ def line_minimization(
         warmup_options = dict(nblocks=1, nsteps_per_block=10, verbose=verbose)
     if "tstep" not in warmup_options and "tstep" in vmcoptions:
         warmup_options["tstep"] = vmcoptions["tstep"]
+    assert npts >= 3, f"linemin npts={npts}; need npts >= 3 for correlated sampling"
 
     # Restart
     iteration_offset = 0
@@ -220,7 +253,7 @@ def line_minimization(
         # include near zero in the fit, and go backwards as well
         # We don't use the above computed value because we are
         # doing correlated sampling.
-        steps = np.linspace(-steprange / npts, steprange, npts)
+        steps = np.linspace(-steprange / (npts - 2), steprange, npts)
         params = [x0 + update(pgrad, Sij, step, **update_kws) for step in steps]
         if client is None:
             stepsdata = correlated_compute(wf, coords, params, pgrad_acc)
@@ -235,7 +268,7 @@ def line_minimization(
         en = np.real(np.mean(stepsdata["total"] * stepsdata["weight"], axis=1))
         yfit.extend(en)
         xfit.extend(steps)
-        est_min = stable_fit(xfit, yfit)
+        est_min = stable_fit3(xfit, yfit)
         x0 += update(pgrad, Sij, est_min, **update_kws)
         step_data["tau"] = xfit
         step_data["yfit"] = yfit

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -672,7 +672,7 @@ def optimize_orthogonal(
 
         print("|total_derivative|", np.linalg.norm(total_derivative))
         if len(xfit) > 2:
-            min_tstep = pyqmc.linemin.stable_fit2(xfit, yfit)
+            min_tstep = pyqmc.linemin.stable_fit(xfit, yfit)
             print("chose to move", min_tstep, flush=True)
             parameters = parameters + conditioner(
                 total_derivative, condition, min_tstep


### PR DESCRIPTION
linemin was using a fit procedure that sometimes made poor moves. This is improved by two changes:
1) include the current parameter point in the list of correlated samples
2) if the proposed move is higher than the minimum test point, use the minimum test point instead.