### PR TITLE
fixed not passing the tolerance to the Slater determinant.

### DIFF
--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -29,8 +29,17 @@ def get_complex_phase(x):
     return x / np.abs(x)
 
 
-def choose_evaluator_from_pyscf(mol, mf, mc=None, twist=None, determinants=None):
+def choose_evaluator_from_pyscf(mol, mf, mc=None, twist=None, determinants=None, tol=None):
     """
+    mol: A Mole object
+    mf: a pyscf mean-field object
+    mc: a pyscf multiconfigurational object. Supports HCI and CAS 
+    twist: the twist of the calculation (units?)
+    determinants: A list of determinants suitable to pass into create_packed_objects
+    tol: smallest determinant weight to include in the wave function.
+
+    You cannot pass both mc/tol and determinants. 
+
     Returns:
     an orbital evaluator chosen based on the inputs.
     """
@@ -45,7 +54,7 @@ def choose_evaluator_from_pyscf(mol, mf, mc=None, twist=None, determinants=None)
         )
     if mc is None:
         return MoleculeOrbitalEvaluator.from_pyscf(mol, mf, determinants=determinants)
-    return MoleculeOrbitalEvaluator.from_pyscf(mol, mf, mc, determinants=determinants)
+    return MoleculeOrbitalEvaluator.from_pyscf(mol, mf, mc, determinants=determinants, tol=tol)
 
 
 class MoleculeOrbitalEvaluator:

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -124,7 +124,7 @@ class Slater:
             self._det_map,
             self.orbitals,
         ) = pyqmc.orbitals.choose_evaluator_from_pyscf(
-            mol, mf, mc, twist=twist, determinants=determinants
+            mol, mf, mc, twist=twist, determinants=determinants, tol=self.tol
         )
 
         self.parameters = JoinParameters([self.myparameters, self.orbitals.parameters])


### PR DESCRIPTION
Fixed a problem noted by Shunyue. This was not giving the expected output:
```
import numpy as np
import pyscf
import pyscf.hci
import h5py 
import pyqmc.api as pyq


def hartree_fock(xyz, chkfile, spin=0, basis='vtz'):
    mol = pyscf.gto.M(atom = xyz, basis=f'ccecpccp{basis}', ecp='ccecp', unit='bohr', charge=0, spin=spin, verbose=5)
    mf = pyscf.scf.ROHF(mol)
    # mf.callback = partial(save_scf_iteration,chkfile)
    mf.chkfile=chkfile
    dm = mf.init_guess_by_atom()
    mf.kernel(dm)


def run_hci(hf_chkfile, chkfile, select_cutoff=0.1, nroots=4):
    mol, mf = pyq.recover_pyscf(hf_chkfile, cancel_outputs=False)
    cisolver = pyscf.hci.SCI(mol)
    cisolver.select_cutoff=select_cutoff
    cisolver.nroots=nroots
    nmo = mf.mo_coeff.shape[1]
    nelec = mol.nelec
    h1 = mf.mo_coeff.T.dot(mf.get_hcore()).dot(mf.mo_coeff)
    h2 = pyscf.ao2mo.full(mol, mf.mo_coeff)
    e, civec = cisolver.kernel(h1, h2, nmo, nelec, verbose=0)
    cisolver.ci= np.array(civec)
    rdm1,rdm2 = cisolver.make_rdm12s(civec[0], nmo, nelec)
    pyscf.lib.chkfile.save(chkfile,'ci',
        {'ci':cisolver.ci,
        'nmo':nmo,
        'nelec':nelec,
        '_strs':cisolver._strs,
        'select_cutoff':select_cutoff,
        'energy':e+mol.energy_nuc(),
        'rdm':np.array(rdm1)
        })


def recover_hci(hf_chkfile, ci_chkfile):
    mol, mf = pyq.recover_pyscf(hf_chkfile)
    cisolver = pyscf.hci.SCI(mol)
    cisolver.__dict__.update(pyscf.lib.chkfile.load(ci_chkfile,'ci'))
    return mol, mf, cisolver

def generate_wf_gs(hf_chkfile, ci_chkfile, slater_kws=None):
    if ci_chkfile is not None:
        mol, mf, cisolver = recover_hci(hf_chkfile, ci_chkfile)
        cisolver.ci=cisolver.ci[0]
        wf, to_opt = pyq.generate_wf(mol, mf, mc=cisolver, slater_kws=slater_kws)
    else: 
        mol, mf = pyq.recover_pyscf(hf_chkfile)
        wf, to_opt = pyq.generate_wf(mol, mf, slater_kws=slater_kws)
    return mol, mf, wf, to_opt

def optimize_gs(hf_chkfile, ci_chkfile, opt_chkfile, start_from=None, slater_kws=None, nconfig=1000, **kwargs):
    mol, mf, wf, to_opt = generate_wf_gs(hf_chkfile, ci_chkfile, slater_kws)
    for k, it in to_opt.items():
        print(k,it.shape, np.sum(it))
    #if start_from is not None:
    #    print("reading from", start_from)
     #   pyq.read_wf(wf, start_from)
    #configs = pyq.initial_guess(mol, nconfig)
    #acc = pyq.gradient_generator(mol, wf, to_opt)
    #pyq.line_minimization(wf, configs, acc, verbose=True, hdf_file = opt_chkfile, **kwargs)


xyz = "H 0. 0. 0.; H 0. 0. 1.4; H 0. 0. 2.8; H 0. 0. 4.2"
mf =  "h4_1.4_vtz_mf.chk"
hci = "h4_1.4_vtz_hci0.01.chk"

hartree_fock(xyz, mf, spin=0, basis='vtz')
run_hci(mf,hci, 0.01)


output1 = "h4_1.4_vtz_opt_hci0.01_0.000001_large_0_400.chk"
slater_kws_1={'optimize_orbitals':True, 'optimize_zeros':False, 'optimize_determinants':True}
slater_kws_1['tol'] = 0.000001

optimize_gs(mf, hci, output1, start_from=None, nconfig = 400, slater_kws=slater_kws_1)

output2 = "h4_1.4_vtz_opt_hci0.01_0.05_large_0_400.chk"
slater_kws_2={'optimize_orbitals':True, 'optimize_zeros':False, 'optimize_determinants':True}
slater_kws_2['tol'] = 0.1

optimize_gs(mf, hci, output2, start_from=None, nconfig = 400, slater_kws=slater_kws_2)
```