### PR TITLE
move arrays to gpus for calculating ewald gpoints

### DIFF
--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -381,7 +381,9 @@ class Ewald:
 
 
 def select_big(gpts, cellvolume, recvec, alpha):
-    gpoints = gpu.cp.einsum("j...,jk->...k", gpts, recvec) * 2 * np.pi
+    gpoints = gpu.cp.einsum(
+        "j...,jk->...k", gpu.cp.asarray(gpts), gpu.cp.asarray(recvec) * 2 * np.pi
+    )
     gsquared = gpu.cp.einsum("...k,...k->...", gpoints, gpoints)
     gweight = 4 * np.pi * gpu.cp.exp(-gsquared / (4 * alpha ** 2))
     gweight /= cellvolume * gsquared


### PR DESCRIPTION
cupy.einsum can only act on cupy arrays; it doesn't automatically convert from numpy, so that has to be done explicitly.