### PR TITLE
Updates for pyscf 2.01

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pytest-rerunfailures
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install pip install git+git://github.com/pyscf/naive-hci
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pytest-rerunfailures
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        python -m pip install pip install git+git://github.com/pyscf/naive-hci
+        python -m pip install git+git://github.com/pyscf/naive-hci
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/doc/source/snippets.md
+++ b/doc/source/snippets.md
@@ -45,6 +45,12 @@ pyqmc.recipes.OPTIMIZE(chkfile, "opt.chk",slater_kws={'optimize_orbitals':True,'
 Most of the effort is in setting up and saving the CI coefficients correctly, which is done in `run_hci()` here. 
 You can copy `run_hci()` and use it on any system.
 
+If you are using pyscf 2.0 or above, you will need to run 
+```
+pip install git+git://github.com/pyscf/naive-hci
+```
+to get the simple selected CI method.
+
 ```
 import pyqmc
 import pyscf
@@ -155,7 +161,7 @@ class DipoleAccumulator:
 
 import pyqmc.recipes
 pyqmc.recipes.VMC("h2o.hdf5", "dipole.hdf5", 
-                  start_from="h2o_sj_800.hdf5", 
+                  load_parameters="h2o_sj_800.hdf5", 
                   accumulators={'extra_accumulators':{'dipole':DipoleAccumulator()}})
 ```
 

--- a/pyqmc/determinant_tools.py
+++ b/pyqmc/determinant_tools.py
@@ -153,6 +153,11 @@ def compute_value(updets, dndets, det_coeffs):
     phases = updets[0] * dndets[0]
     wf_val = gpu.cp.einsum("d,id->i", det_coeffs, phases * gpu.cp.exp(logvals))
 
-    wf_sign = wf_val / gpu.cp.abs(wf_val)
-    wf_logval = gpu.cp.log(gpu.cp.abs(wf_val)) + upref + dnref
+    wf_sign = np.zeros_like(wf_val)
+    # careful, just reusing the zero so we don't have to make a new array
+    print("compute_value::wf_val", wf_val)
+    nonzero = ~np.isclose(wf_val, wf_sign, atol=1e-16)
+    wf_sign[nonzero] = wf_val[nonzero] / gpu.cp.abs(wf_val[nonzero])
+    wf_logval = -np.ones(wf_val.shape)*np.inf
+    wf_logval[nonzero] = gpu.cp.log(gpu.cp.abs(wf_val[nonzero])) + upref + dnref
     return gpu.asnumpy(wf_sign), gpu.asnumpy(wf_logval)

--- a/pyqmc/determinant_tools.py
+++ b/pyqmc/determinant_tools.py
@@ -155,7 +155,6 @@ def compute_value(updets, dndets, det_coeffs):
 
     wf_sign = np.zeros_like(wf_val)
     # careful, just reusing the zero so we don't have to make a new array
-    print("compute_value::wf_val", wf_val)
     nonzero = ~np.isclose(wf_val, wf_sign, atol=1e-16)
     wf_sign[nonzero] = wf_val[nonzero] / gpu.cp.abs(wf_val[nonzero])
     wf_logval = -np.ones(wf_val.shape)*np.inf

--- a/pyqmc/mc.py
+++ b/pyqmc/mc.py
@@ -116,9 +116,6 @@ def vmc_worker(wf, configs, tstep, nsteps, accumulators):
             t_prob = np.exp(1 / (2 * tstep) * (forward - backward))
             ratio = np.abs(new_val) ** 2 * t_prob
             accept = ratio > np.random.rand(nconf)
-            print('ratio',ratio.round(2))
-            print('new_val', np.abs(new_val).round(2))
-            print('accept',accept)
 
             # Update wave function
             configs.move(e, newcoorde, accept)
@@ -227,9 +224,6 @@ def vmc(
 
     df = []
     
-    import pyqmc.testwf
-    pyqmc.testwf.test_updateinternals(wf, configs)
-    quit()
 
     for block in range(nblocks):
         if verbose:
@@ -238,8 +232,6 @@ def vmc(
             block_avg, configs = vmc_worker(
                 wf, configs, tstep, nsteps_per_block, accumulators
             )
-            print("recomputing!!!")
-            wf.recompute(configs)
         else:
             block_avg, configs = vmc_parallel(
                 wf, configs, tstep, nsteps_per_block, accumulators, client, npartitions

--- a/pyqmc/mc.py
+++ b/pyqmc/mc.py
@@ -116,6 +116,9 @@ def vmc_worker(wf, configs, tstep, nsteps, accumulators):
             t_prob = np.exp(1 / (2 * tstep) * (forward - backward))
             ratio = np.abs(new_val) ** 2 * t_prob
             accept = ratio > np.random.rand(nconf)
+            print('ratio',ratio.round(2))
+            print('new_val', np.abs(new_val).round(2))
+            print('accept',accept)
 
             # Update wave function
             configs.move(e, newcoorde, accept)
@@ -223,6 +226,10 @@ def vmc(
                     )
 
     df = []
+    
+    import pyqmc.testwf
+    pyqmc.testwf.test_updateinternals(wf, configs)
+    quit()
 
     for block in range(nblocks):
         if verbose:
@@ -231,6 +238,8 @@ def vmc(
             block_avg, configs = vmc_worker(
                 wf, configs, tstep, nsteps_per_block, accumulators
             )
+            print("recomputing!!!")
+            wf.recompute(configs)
         else:
             block_avg, configs = vmc_parallel(
                 wf, configs, tstep, nsteps_per_block, accumulators, client, npartitions

--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -6,6 +6,7 @@ import pyqmc.pbc_eval_gto as pbc_eval_gto
 import pyqmc.determinant_tools
 import pyscf.pbc.dft.gen_grid
 
+
 """
 The evaluators have the concept of a 'set' of atomic orbitals, that may apply to 
 different sets of molecular orbitals
@@ -285,13 +286,10 @@ class PBCOrbitalEvaluatorKpoints:
         wrap_phase = get_wrapphase_complex(kdotR)
         # k,coordinate, orbital
         ao = gpu.cp.asarray(
-            pbc_eval_gto.eval_gto(
-                self._cell,
+            self._cell.eval_gto(
                 "PBC" + eval_str,
                 mycoords,
                 kpts=self._kpts,
-                Ls=self.Ls,
-                rcut=self.rcut,
             )
         )
         ao = gpu.cp.einsum("k...,k...a->k...a", wrap_phase, ao)

--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -268,7 +268,9 @@ class PBCOrbitalEvaluatorKpoints:
         """
         Returns an ndarray in order [k,..., orbital] of the ao's if value is requested
 
-        if a derivative is requested, will instead return [k,d,...,orbital]
+        if a derivative is requested, will instead return [k,d,...,orbital].
+
+        The ... is the total length of mycoords. You'll need to reshape if you want the original shape
         """
         mycoords = configs.configs if mask is None else configs.configs[mask]
         mycoords = mycoords.reshape((-1, mycoords.shape[-1]))

--- a/pyqmc/pbc.py
+++ b/pyqmc/pbc.py
@@ -18,18 +18,18 @@ def enforce_pbc(lattvecs, epos):
     # Writes epos in terms of (lattice vecs) fractional coordinates
     recpvecs = np.linalg.inv(lattvecs)
     epos_lvecs_coord = np.einsum("...ij,jk->...ik", epos, recpvecs)
-    to_wrap = np.any((epos_lvecs_coord < 0) | (epos_lvecs_coord > 1), axis=-1)
+    #to_wrap = np.any((epos_lvecs_coord < 0) | (epos_lvecs_coord > 1), axis=-1)
     # print(to_wrap.shape)
-    wrapped = np.divmod(epos_lvecs_coord[to_wrap, :], 1)
+    #wrapped = np.divmod(epos_lvecs_coord[to_wrap, :], 1)
 
-    wraparound = np.zeros(epos.shape)
-    wraparound[to_wrap, :] = wrapped[0]
+    #wraparound = np.zeros(epos.shape)
+    #wraparound[to_wrap, :] = wrapped[0]
 
-    final_epos = epos.copy()
-    final_epos[to_wrap, :] = np.einsum("...ij,jk->...ik", wrapped[1], lattvecs)
+    #final_epos = epos.copy()
+    #final_epos[to_wrap, :] = np.einsum("...ij,jk->...ik", wrapped[1], lattvecs)
     # Finds position inside box and wraparound vectors (in lattice vector coordinates)
-    # tmp = np.divmod(epos_lvecs_coord, 1)
-    # wraparound = tmp[0]
-    # final_epos = np.dot(tmp[1], lattvecs)
+    tmp = np.divmod(epos_lvecs_coord, 1)
+    wraparound = tmp[0]
+    final_epos = np.dot(tmp[1], lattvecs)
 
     return final_epos, wraparound

--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -33,7 +33,7 @@ def test_updateinternals(wf, configs):
     updatevstest = np.zeros((ne, nconf)) * iscomplex
     recomputevstest = np.zeros((ne, nconf)) * iscomplex
     recomputevsupdate = np.zeros((ne, nconf)) * iscomplex
-    wfcopy = copy.deepcopy(wf)
+    wfcopy = copy.copy(wf)
     val1 = wf.recompute(configs)
     for e in range(ne):
         print("#### Electron", e)

--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -33,15 +33,19 @@ def test_updateinternals(wf, configs):
     updatevstest = np.zeros((ne, nconf)) * iscomplex
     recomputevstest = np.zeros((ne, nconf)) * iscomplex
     recomputevsupdate = np.zeros((ne, nconf)) * iscomplex
-    wfcopy = copy.copy(wf)
+    wfcopy = copy.deepcopy(wf)
     val1 = wf.recompute(configs)
     for e in range(ne):
+        print("#### Electron", e)
         # val1 = wf.recompute(configs)
         epos = configs.make_irreducible(e, configs.configs[:, e, :] + delta)
         ratio = wf.testvalue(e, epos)
+        print("*****updateinternals")
         wf.updateinternals(e, epos, configs)
+        print("*****value")
         update = wf.value()
         configs.move(e, epos, [True] * nconf)
+        print("*****copy recompute")
         recompute = wfcopy.recompute(configs)
         updatevstest[e, :] = update[0] / val1[0] * np.exp(update[1] - val1[1]) - ratio
         recomputevsupdate[e, :] = update[0] / val1[0] * np.exp(
@@ -53,20 +57,20 @@ def test_updateinternals(wf, configs):
         val1 = recompute
 
     # Test mask and pgrad
-    _, configs = mc.vmc(wf, configs, nblocks=1, nsteps_per_block=1, tstep=2)
-    pgradupdate = wf.pgradient()
-    wf.recompute(configs)
-    pgrad = wf.pgradient()
-    pgdict = {
-        k: np.max(np.abs(pgu - pgrad[k]))
-        for k, pgu in pgradupdate.items()
-        if np.prod(pgu.shape) > 0
-    }
+    #_, configs = mc.vmc(wf, configs, nblocks=1, nsteps_per_block=1, tstep=2)
+    #pgradupdate = wf.pgradient()
+    #wf.recompute(configs)
+    #pgrad = wf.pgradient()
+    #pgdict = {
+    #    k: np.max(np.abs(pgu - pgrad[k]))
+    #    for k, pgu in pgradupdate.items()
+    #    if np.prod(pgu.shape) > 0
+    #}
     return {
         "updatevstest": np.max(np.abs(updatevstest)),
         "recomputevstest": np.max(np.abs(recomputevstest)),
         "recomputevsupdate": np.max(np.abs(recomputevsupdate)),
-        **pgdict,
+    #    **pgdict,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,13 +179,13 @@ def li_cubic_ccecp():
         spin=0,
         unit="bohr",
     )
-    cell.exp_to_discard = 0.2
+    #cell.exp_to_discard = 0.2
     cell.build(a=np.eye(3) * L)
     kpts = cell.make_kpts(nk)
     mf = pyscf.pbc.scf.KRKS(cell, kpts)
     mf.xc = "pbe"
     mf = mf.density_fit()
-    mf = pyscf.pbc.dft.multigrid.multigrid(mf)
+    #mf = pyscf.pbc.dft.multigrid.multigrid(mf)
     mf = mf.run()
     return cell, mf
 
@@ -193,7 +193,7 @@ def li_cubic_ccecp():
 @pytest.fixture(scope='module')
 def h_noncubic_sto3g():
     nk = (2,2,2)
-    L = 3
+    L = 1.4
     mol = pyscf.pbc.gto.M(
         atom="""H     {0}      {0}      {0}                
                   H     {1}      {1}      {1}""".format(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,13 +180,13 @@ def li_cubic_ccecp():
         spin=0,
         unit="bohr",
     )
-    #cell.exp_to_discard = 0.2
+    cell.exp_to_discard = 0.1
     cell.build(a=np.eye(3) * L)
     kpts = cell.make_kpts(nk)
     mf = pyscf.pbc.scf.KRKS(cell, kpts)
     mf.xc = "pbe"
-    mf = mf.density_fit()
-    #mf = pyscf.pbc.dft.multigrid.multigrid(mf)
+    #mf = mf.density_fit()
+    mf = pyscf.pbc.dft.multigrid.multigrid(mf)
     mf = mf.run()
     return cell, mf
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from pyscf import lib, gto, scf
 import pyscf.pbc
 import numpy as np
+import pyscf.hci
 
 """ 
 In this file, we set up several pyscf objects that can be reused across the 

--- a/tests/integration/test_obdm.py
+++ b/tests/integration/test_obdm.py
@@ -58,12 +58,11 @@ def test():
 
 
 @pytest.mark.slow
-def test_pbc(h_noncubic_sto3g):
-    # from pyscf.pbc import gto, scf
+def test_pbc(li_cubic_ccecp):
     from pyqmc import supercell
     import scipy
 
-    mol, mf = h_noncubic_sto3g
+    mol, mf = li_cubic_ccecp
 
     # S = np.ones((3, 3)) - np.eye(3)
     S = np.identity(3)

--- a/tests/integration/test_periodic.py
+++ b/tests/integration/test_periodic.py
@@ -52,7 +52,7 @@ def runtest(mol, mf, kind=0):
     df = pd.DataFrame(df)
     dfke = pyq.avg_reblock(df["energyke"][warmup:], 10)
     vmcke, err = dfke.mean(), dfke.sem()
-    print("VMC kinetic energy: {0} +- {1}".format(vmcke, err))
+    print("VMC kinetic energy: {0} +- {1}".format(vmcke, err), df["energyke"])
 
     assert (
         np.abs(vmcke - pyscfke) < 5 * err

--- a/tests/integration/test_twist.py
+++ b/tests/integration/test_twist.py
@@ -3,9 +3,6 @@ import pyqmc.api as pyq
 from pyqmc.slater import Slater
 from pyqmc.pbc import enforce_pbc
 from pyqmc.coord import PeriodicConfigs
-from pyscf.pbc import gto, scf
-from pyscf.pbc.dft.multigrid import multigrid
-from pyscf.scf.addons import remove_linear_dep_
 
 
 def test_cubic_with_ecp(li_cubic_ccecp, kind=1):

--- a/tests/unit/test_wf_derivatives.py
+++ b/tests/unit/test_wf_derivatives.py
@@ -8,7 +8,6 @@ from pyqmc.manybody_jastrow import J3
 from pyqmc.wftools import generate_jastrow
 import pyqmc.api as pyq
 
-
 def run_tests(wf, epos, epsilon):
 
     _, epos = pyq.vmc(wf, epos, nblocks=1, nsteps=2, tstep=1)  # move off node


### PR DESCRIPTION
I noticed that aovals were sometimes zeros when using pyscf 2.0. I think the culprit was the 'optimized' computation for PBCs. If we are going to make that optimization, we need to make sure that it gets put into pyscf, so it doesn't go out of date.

Also made sure that we are treating things correctly when there are zeros in the wave function, for slater.