### PR TITLE
Tbdm complex

### DIFF
--- a/pyqmc/obdm.py
+++ b/pyqmc/obdm.py
@@ -8,9 +8,9 @@ import pyqmc.supercell as supercell
 
 
 class OBDMAccumulator:
-    r"""Return the obdm as an array with indices rho[spin][i][j] = <c_{spin,i}c^+_{spin,j}>
+    r"""Return the obdm as an array with indices rho[spin][i][j] = <c^+_{spin,i}c_{spin,j}>
 
-    .. math:: \rho^\sigma_{ij} = \langle c_{\sigma, i} c^\dagger_{\sigma, j} \rangle
+    .. math:: \rho^\sigma_{ij} = \langle c^\dagger_{\sigma, i} c_{\sigma, j} \rangle
 
     We are measuring the amplitude of moving one electron (e.g. the first one) from orbital :math:`\phi_i` to orbital :math:`\phi_j` (Eq (7) of DOI:10.1063/1.4793531)
 

--- a/pyqmc/tbdm.py
+++ b/pyqmc/tbdm.py
@@ -224,8 +224,8 @@ class TBDMAccumulator:
                 "nio,nio,no,no,n ->nio",
                 orb_configs[0][:, electrons_a_ind, :],  # phi_i(r1)
                 orb_configs[1][:, electrons_b_ind, :],  # phi_k(r2)
-                phi_j_r1p,  # phi_j
-                phi_l_r2p,  # phi_l
+                phi_j_r1p.conj(),  # phi_j^*(r1)
+                phi_l_r2p.conj(),  # phi_l^*(r2)
                 rho1rho2,
             )
 

--- a/pyqmc/tbdm.py
+++ b/pyqmc/tbdm.py
@@ -9,12 +9,14 @@ import warnings
 
 
 class TBDMAccumulator:
-    """Returns one spin sector of the tbdm[s1,s2] as an array (norb_s1,norb_s1,norb_s2,norb_s2)
+    r"""Returns one spin sector of the tbdm[s1,s2] as an array (norb_s1,norb_s1,norb_s2,norb_s2)
 
     We use PySCF's index convention (note that Eq. 10 in DOI:10.1063/1.4793531 uses QWalk's).
     PySCF -> tbdm[s1,s2,i,j,k,l] = < c^+_{s1,i} c^+_{s2,k} c_{s2,l} c_{s1,j} > = \phi*_{s1,j} \phi*_{s2,l} \phi_{s2,k} \phi_{s1,i}
 
     .. math:: \rho_{ijkl}^{\sigma_1\sigma_2} = \left\langle c^\dagger_{\sigma_1, i} c^\dagger_{\sigma_2, k} c_{\sigma_2, l} c_{\sigma_1, j} \right\rangle = \phi^*_{\sigma_1,j} \phi^*_{\sigma_2,l} \phi_{\sigma_2,k} \phi_{\sigma_1,i}.
+
+    .. math:: \rho_{ijkl} = \left\langle \sum_{a<b} \frac{\Psi(\mathbf{R}'_{ab})}{\Psi(\mathbf{R})} \frac{\phi^*_{j}(\mathbf{r}_a') \phi^*_{l}(\mathbf{r}_b') \phi_{i}(\mathbf{r}_a) \phi_{k}(\mathbf{r}_b) }{\rho_{\rm aux}(\mathbf{r}_a')\rho_{\rm aux}(\mathbf{r}_b')} \right\rangle_{\begin{subarray}{l}\mathbf{R}\sim|\Psi|^2;\\ \mathbf{r}_a'\sim\rho_{\rm aux}\end{subarray}},
 
     QWalk -> tbdm[s1,s2,i,j,k,l] = < c^+_{s1,i} c^+_{s2,j} c_{s2,l} c_{s1,k} > = \phi*_{s1,k} \phi*_{s2,l} \phi_{s2,j} \phi_{s1,i}
 


### PR DESCRIPTION
Mostly add documentation for RDMs. In TBDM, conjugate phi_j(r') and phi_l(r'), which seems to be consistent with the other formulas. 