### PR TITLE
Gpu bugfix

### DIFF
--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -114,7 +114,7 @@ class LinearTransform:
         n = 0
         m = self.nparams
         d = {}
-        frozen_parms = {k: gpu.cp.asnumpy(wf.parameters[k])[~opt] for k, opt in self.to_opt.items()}
+        frozen_parms = {k: gpu.asnumpy(wf.parameters[k])[~opt] for k, opt in self.to_opt.items()}
 
         for k, opt in self.to_opt.items():
             opt_ = opt.flatten()

--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -114,7 +114,7 @@ class LinearTransform:
         n = 0
         m = self.nparams
         d = {}
-        frozen_parms = {k: wf.parameters[k][~opt] for k, opt in self.to_opt.items()}
+        frozen_parms = {k: gpu.cp.asnumpy(wf.parameters[k])[~opt] for k, opt in self.to_opt.items()}
 
         for k, opt in self.to_opt.items():
             opt_ = opt.flatten()

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -410,7 +410,7 @@ class Slater:
             self._dets[1][:, :, self._det_map[1]],
         )
 
-        d["det_coeff"] = np.zeros(dets[0].shape[1:], dtype=dets[0].dtype)
+        d["det_coeff"] = gpu.cp.zeros(dets[0].shape[1:], dtype=dets[0].dtype)
         d["det_coeff"][nonzero, :] = (
             dets[0][0, nonzero, :]
             * dets[1][0, nonzero, :]

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -162,7 +162,7 @@ class Slater:
                 )
                 # print(configs.configs[])
                 print(f"zero {is_zero/np.prod(compute.shape)}")
-            self._inverse.append(np.zeros(mo_vals.shape, dtype=mo_vals.dtype))
+            self._inverse.append(gpu.cp.zeros(mo_vals.shape, dtype=mo_vals.dtype))
             for d in range(compute.shape[1]):
                 self._inverse[s][compute[:, d], d, :, :] = gpu.cp.linalg.inv(
                     mo_vals[compute[:, d], d, :, :]


### PR DESCRIPTION
Joao pointed out a couple errors with arrays on CPU vs GPU: Slater inverse matrices and det_coeff need to be stored on GPU, and frozen_parms in LinearTransform is expected to be on CPU.