### PR TITLE
fix different nelec per kpt -- concatenate flattened occup

### DIFF
--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -192,9 +192,9 @@ def select_orbitals_kpoints(determinants, mf, kinds):
     for wt, det in determinants:
         flattened_det = []
         for det_s, offset_s in zip(det, orb_offsets):
-            flattened = np.array(
+            flattened = np.concatenate(
                 [det_s[k] + offset_s[ki] for ki, k in enumerate(kinds)]
-            ).flatten()
+            ).flatten().astype(int)
             flattened_det.append(list(flattened))
         determinants_flat.append((wt, flattened_det))
     return mo_coeff, determinants_flat


### PR DESCRIPTION
This should resolve issue #292 , that varying number of electrons per kpt raised an error. The test case in #292 no longer errors.