### PR TITLE
increase optimization warmup default to 100 steps

### DIFF
--- a/pyqmc/linemin.py
+++ b/pyqmc/linemin.py
@@ -131,7 +131,7 @@ def line_minimization(
     if update_kws is None:
         update_kws = {}
     if warmup_options is None:
-        warmup_options = dict(nblocks=3, nsteps_per_block=10, verbose=verbose)
+        warmup_options = dict(nblocks=1, nsteps_per_block=100)
     if "tstep" not in warmup_options and "tstep" in vmcoptions:
         warmup_options["tstep"] = vmcoptions["tstep"]
     assert npts >= 3, f"linemin npts={npts}; need npts >= 3 for correlated sampling"
@@ -183,7 +183,7 @@ def line_minimization(
     # VMC warm up period
     if verbose:
         print("starting warmup")
-    data, coords = pyqmc.mc.vmc(
+    _, coords = pyqmc.mc.vmc(
         wf,
         coords,
         accumulators={},


### PR DESCRIPTION
old warmup default was nblocks=3, nsteps_per_block=10
changed to: nblocks=1, nsteps_per_block=100

Better default of 100 steps instead of just 30, and can do all in one block for efficiency since we don't collect any data.