### PR TITLE
fix bug saving new pbc configs shape

### DIFF
--- a/pyqmc/coord.py
+++ b/pyqmc/coord.py
@@ -222,8 +222,8 @@ class PeriodicConfigs:
 
     def to_hdf(self, hdf):
         hdf["configs"].resize(self.configs.shape)
-        hdf["configs"].resize(self.wrap.shape)
         hdf["configs"][...] = self.configs
+        hdf["wrap"].resize(self.wrap.shape)
         hdf["wrap"][...] = self.wrap
 
     def load_hdf(self, hdf):


### PR DESCRIPTION
Problem: configs was resized when a new shape was saved, but wrap was not resized for wrap shape (configs was resized again)
Fix: resize wrap for wrap shape