### PR TITLE
Some bugfixes with CASCI recipe

### DIFF
--- a/pyqmc/coord.py
+++ b/pyqmc/coord.py
@@ -222,8 +222,8 @@ class PeriodicConfigs:
 
     def to_hdf(self, hdf):
         hdf["configs"].resize(self.configs.shape)
-        hdf["configs"].resize(self.wrap.shape)
         hdf["configs"][...] = self.configs
+        hdf["wrap"].resize(self.wrap.shape)
         hdf["wrap"][...] = self.wrap
 
     def load_hdf(self, hdf):

--- a/pyqmc/determinant_tools.py
+++ b/pyqmc/determinant_tools.py
@@ -169,11 +169,11 @@ def translate_occ(x, orbitals, nocc):
 
 
 def pbc_determinants_from_casci(mc, orbitals, cutoff=0.05):
-    if hasattr(mc.ncore, "len"):
+    if hasattr(mc.ncore, "__len__"):
         nocc = [c + e for c, e in zip(mc.ncore, mc.nelecas)]
     else:
         nocc = [mc.ncore + e for e in mc.nelecas]
-    if not hasattr(orbitals[0], "len"):
+    if not hasattr(orbitals[0], "__len__"):
         orbitals = [orbitals, orbitals]
     deters = fci.addons.large_ci(mc.ci, mc.ncas, mc.nelecas, tol=-1)
     determinants = []
@@ -183,5 +183,5 @@ def pbc_determinants_from_casci(mc, orbitals, cutoff=0.05):
                 [translate_occ(x[1], orbitals[0], nocc[0])],
                 [translate_occ(x[2], orbitals[1], nocc[1])],
             ]
-            determinants.append((x[0], *allorbs))
+            determinants.append((x[0], allorbs))
     return determinants

--- a/pyqmc/pyscftools.py
+++ b/pyqmc/pyscftools.py
@@ -1,6 +1,6 @@
 import pyscf
 import pyscf.pbc
-import pyscf.mcscf.casci as casci
+import pyscf.mcscf
 import h5py
 import json
 
@@ -66,7 +66,10 @@ def recover_pyscf(chkfile, ci_checkfile=None, cancel_outputs=True):
         if hci:
             mc = pyscf.hci.SCI(mol)
         else:
-            mc = casci.CASCI(mol, casdict["ncas"], casdict["nelecas"])
+            if len(casdict["mo_coeff"].shape) == 3:
+                mc = pyscf.mcscf.UCASCI(mol, casdict["ncas"], casdict["nelecas"])
+            else:
+                mc = pyscf.mcscf.CASCI(mol, casdict["ncas"], casdict["nelecas"])
         mc.__dict__.update(casdict)
 
         return mol, mf, mc

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -114,7 +114,10 @@ class Slater:
         self._mol = mol
         if hasattr(mc, "nelecas"):
             # In case nelecas overrode the information from the molecule object.
-            self._nelec = (mc.nelecas[0] + mc.ncore, mc.nelecas[1] + mc.ncore)
+            ncore = mc.ncore 
+            if not hasattr(ncore, "__len__"):
+                ncore = [ncore, ncore]
+            self._nelec = (mc.nelecas[0] + ncore[0], mc.nelecas[1] + ncore[1])
         else:
             self._nelec = mol.nelec
 


### PR DESCRIPTION
-Checked for attribute "len" instead of "__len__"
-Create UCASCI when reading UHF
-Fix determinant list format
-Correctly handle when ncore is a 2-tuple instead of int