### PR TITLE
add spinSq to SqAccumulator

### DIFF
--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -228,9 +228,8 @@ class SqAccumulator:
         """
         Inputs:
             cell: pyscf Cell object
-            qlist: (n, 3) array-like. If qlist is provided, Lvecs and nq are ignored
-            Lvecs: (3, 3) array-like of lattice vectors. Required if qlist is None
-            nq: int, if qlist is nonzero, use a uniform grid of shape (nq, nq, nq)
+            nq: int. If qlist is nonzero, use a uniform grid of shape (nq, nq, nq)
+            qlist: (n, 3) array-like. If qlist is provided, nq is ignored
         """
         if qlist is not None:
             self.qlist = qlist

--- a/tests/unit/test_accumulators.py
+++ b/tests/unit/test_accumulators.py
@@ -42,7 +42,7 @@ def test_info_functions_pbc(H_pbc_sto3g_krks):
     accumulators = {
         "pgrad": pyq.gradient_generator(mol, wf, to_opt, ewald_gmax=10),
         "obdm": OBDMAccumulator(mol, dm_orbs, kpts=mf.kpts[kinds]),
-        "Sq": SqAccumulator(mol.lattice_vectors()),
+        "Sq": SqAccumulator(mol.nelec, mol.lattice_vectors()),
     }
     info_functions(mol, wf, accumulators)
 

--- a/tests/unit/test_accumulators.py
+++ b/tests/unit/test_accumulators.py
@@ -42,7 +42,7 @@ def test_info_functions_pbc(H_pbc_sto3g_krks):
     accumulators = {
         "pgrad": pyq.gradient_generator(mol, wf, to_opt, ewald_gmax=10),
         "obdm": OBDMAccumulator(mol, dm_orbs, kpts=mf.kpts[kinds]),
-        "Sq": SqAccumulator(mol.nelec, mol.lattice_vectors()),
+        "Sq": SqAccumulator(mol),
     }
     info_functions(mol, wf, accumulators)
 

--- a/tests/unit/test_ewald.py
+++ b/tests/unit/test_ewald.py
@@ -123,7 +123,8 @@ def compute_ewald_shifted(x, delta, L=4.0):
     configs = np.full((1, 1, 3), x * L) + delta
     configs = PeriodicConfigs(configs, cell.lattice_vectors())
     evaluator = pyqmc.ewald.Ewald(cell, ewald_gmax=25)
-    return evaluator.energy(configs)
+    energy = evaluator.energy(configs)
+    return np.concatenate([np.ravel(a) for a in energy])
 
 
 def test_ewald_shifted():

--- a/tests/unit/test_sq.py
+++ b/tests/unit/test_sq.py
@@ -3,7 +3,6 @@ from pyqmc.coord import PeriodicConfigs
 import numpy as np
 import pandas as pd
 import pyscf.pbc
-import matplotlib.pyplot as plt
 
 
 def test_config():

--- a/tests/unit/test_sq.py
+++ b/tests/unit/test_sq.py
@@ -73,15 +73,18 @@ def test_big_cell():
     df = run(Lvecs, configs, 8)
     df = df.groupby("qmag").mean().reset_index()
 
-    large_q = df[-35:-10]["Sq"]
-    mean = np.mean(large_q - 1)
-    rms = np.sqrt(np.mean((large_q - 1) ** 2))
-    assert np.abs(mean) < 0.01, mean
-    assert rms < 0.1, rms
+    for k in ["Sq", "spinSq"]:
+        large_q = df[-35:-10][k]
+        mean = np.mean(large_q - 1)
+        rms = np.sqrt(np.mean((large_q - 1) ** 2))
+        assert np.abs(mean) < 0.01, mean
+        assert rms < 0.1, rms
 
 
 def run(Lvecs, configs, nq):
-    sqacc = SqAccumulator(Lvecs=Lvecs, nq=nq)
+    nelec = configs.shape[1]
+    nelec_pair = (int(nelec / 2), nelec - int(nelec / 2))
+    sqacc = SqAccumulator(nelec_pair, Lvecs=Lvecs, nq=nq)
     configs = PeriodicConfigs(configs, Lvecs)
     sqavg = sqacc.avg(configs, None)
     df = {"qmag": np.linalg.norm(sqacc.qlist, axis=1)}

--- a/tests/unit/test_sq.py
+++ b/tests/unit/test_sq.py
@@ -82,9 +82,6 @@ def test_big_cell():
 
     df = run(cell, configs, 8)
     df = df.groupby("qmag").mean().reset_index()
-    df.plot("qmag", "Sq")
-    df.plot("qmag", "spinSq")
-    plt.show()
 
     for k in ["Sq", "spinSq"]:
         large_q = df[-35:-10][k]


### PR DESCRIPTION
This PR adds spinSq to the existing SqAccumulator. Since most of the calculation is the same for Sq and spin-Sq, and they are pretty cheap anyway, it seemed simpler to compute them together rather than make a new accumulator that is almost the same. 

Both Sq and spinSq pass the test that at large q they approach 1.

A notable change is that the constructor requires an extra argument, the electron numbers (nup, ndown).