### PR TITLE
Added SymmetryAccumulator class to accumulators.py

### DIFF
--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -293,13 +293,12 @@ class SymmetryAccumulator:
         configs_copy = copy.deepcopy(configs)
         for S_name, S_matrix in self.symmetry_operators.items():
             configs_copy.configs = np.einsum(
-                "ijk,kl->ijl", configs_copy.configs, S_matrix
+                "ijk,kl->ijl", configs.configs, S_matrix
             )
             transformed_wf_value = wf.recompute(configs_copy)
             symmetry_observables[S_name] = (transformed_wf_value[0] / original_wf_value[0]) * np.exp(
                 transformed_wf_value[1] - original_wf_value[1]
             )
-            configs_copy = configs
         wf.recompute(configs)
         return symmetry_observables
 

--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -270,26 +270,28 @@ class SymmetryAccumulator:
     def __init__(self, symm_matrix_repr):
         """
         Inputs:
-            symm_matrix_repr: (3,3) numpy array. Matrix representation of the symmetry operator in real space
+            symm_matrix_repr: (3,3) numpy array. Matrix representation of the symmetry operator S in real space
         """
         self.rot_matrix = symm_matrix_repr
 
     def __call__(self, configs, wf):
         configs_copy = copy.deepcopy(configs)
-        wf_copy = copy.deepcopy(wf)
-        original_value = wf_copy.value()
+        original_value = wf.value()
         configs_copy.configs = np.einsum(
             "ijk,kl->ijl", configs_copy.configs, self.rot_matrix
         )
-        new_value = wf_copy.recompute(configs_copy)
-        symm = (new_value[0] / original_value[0]) * np.exp(
+        new_value = wf.recompute(configs_copy)
+        S_Psi_Over_Psi = (new_value[0] / original_value[0]) * np.exp(
             new_value[1] - original_value[1]
         )
-        return {"": symm}
+        return {"value": S_Psi_Over_Psi}
 
     def avg(self, configs, wf):
         return {k: np.mean(it, axis=0) for k, it in self(configs, wf).items()}
 
     def keys(self):
         return self.shapes().keys()
+
+    def shapes(self):  
+        return {"value": ()}
 

--- a/pyqmc/accumulators.py
+++ b/pyqmc/accumulators.py
@@ -263,28 +263,43 @@ class SqAccumulator:
 
 class SymmetryAccumulator:
     """
-    Accumulates the many-body symmetry of the wave function
-    For example, rotation or reflection about the z-axis
+    Accumulates <S Psi / Psi> for many-body symmetry operator S
+    When defining a SymmetryAccumulator object, pass in the 3x3 unitary matrix corresponding to S
+    For example, to evaluate a rotation of angle theta about the z-axis, pass in
+    rotation_z = np.array(
+        [
+            [np.cos(theta), -np.sin(theta), 0],
+            [np.sin(theta), np.cos(theta), 0],
+            [0, 0, 1],
+        ]
+    )
+    or to evaluate mirror reflection about the yz plane, pass in
+    reflection_yz = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    To accumulate <S Psi / Psi> for both of these symmetry operations, define two separate SymmetryAccumulator objects as
+    acc = {
+        "rotation_z": SymmetryAccumulator(transformation_matrix=rotation_z),
+        "reflection_yz": SymmetryAccumulator(transformation_matrix=reflection_yz),
+    }
     """
 
-    def __init__(self, symm_matrix_repr):
+    def __init__(self, transformation_matrix):
         """
         Inputs:
-            symm_matrix_repr: (3,3) numpy array. Matrix representation of the symmetry operator S in real space
+            transformation_matrix: (3, 3) numpy array. Unitary transformation matrix correspondong to symmetry operator S
         """
-        self.rot_matrix = symm_matrix_repr
+        self.transformation_matrix = transformation_matrix
 
     def __call__(self, configs, wf):
         configs_copy = copy.deepcopy(configs)
         original_value = wf.value()
         configs_copy.configs = np.einsum(
-            "ijk,kl->ijl", configs_copy.configs, self.rot_matrix
+            "ijk,kl->ijl", configs_copy.configs, self.transformation_matrix
         )
         new_value = wf.recompute(configs_copy)
         S_Psi_Over_Psi = (new_value[0] / original_value[0]) * np.exp(
             new_value[1] - original_value[1]
         )
-        return {"value": S_Psi_Over_Psi}
+        return {"S_Psi_Over_Psi": S_Psi_Over_Psi}
 
     def avg(self, configs, wf):
         return {k: np.mean(it, axis=0) for k, it in self(configs, wf).items()}
@@ -293,5 +308,5 @@ class SymmetryAccumulator:
         return self.shapes().keys()
 
     def shapes(self):  
-        return {"value": ()}
+        return {"S_Psi_Over_Psi": ()}
 

--- a/tests/unit/test_accumulators.py
+++ b/tests/unit/test_accumulators.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pyqmc.accumulators import EnergyAccumulator, LinearTransform, SqAccumulator
+from pyqmc.accumulators import EnergyAccumulator, LinearTransform, SqAccumulator, SymmetryAccumulator
 from pyqmc.obdm import OBDMAccumulator
 from pyqmc.tbdm import TBDMAccumulator
 import pyqmc.api as pyq
@@ -28,6 +28,7 @@ def test_info_functions_mol(LiH_sto3g_rhf):
         "pgrad": pyq.gradient_generator(mol, wf, to_opt),
         "obdm": OBDMAccumulator(mol, orb_coeff=mf.mo_coeff),
         "tbdm_updown": TBDMAccumulator(mol, np.asarray([mf.mo_coeff] * 2), (0, 1)),
+        "rotation_z_pi": SymmetryAccumulator(symm_matrix_repr=np.array([[-1, 0, 0],[0, -1, 0],[0, 0, 1]]))
     }
     info_functions(mol, wf, accumulators)
 

--- a/tests/unit/test_accumulators.py
+++ b/tests/unit/test_accumulators.py
@@ -24,11 +24,13 @@ def test_transform(LiH_sto3g_rhf):
 def test_info_functions_mol(LiH_sto3g_rhf):
     mol, mf = LiH_sto3g_rhf
     wf, to_opt = pyq.generate_wf(mol, mf)
+    reflection_yz = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    symmetry_operators = {"reflection_yz": reflection_yz}
     accumulators = {
         "pgrad": pyq.gradient_generator(mol, wf, to_opt),
         "obdm": OBDMAccumulator(mol, orb_coeff=mf.mo_coeff),
         "tbdm_updown": TBDMAccumulator(mol, np.asarray([mf.mo_coeff] * 2), (0, 1)),
-        "rotation_z_pi": SymmetryAccumulator(transformation_matrix=np.array([[-1, 0, 0],[0, -1, 0],[0, 0, 1]]))
+        "symmetry": SymmetryAccumulator(symmetry_operators=symmetry_operators),
     }
     info_functions(mol, wf, accumulators)
 

--- a/tests/unit/test_accumulators.py
+++ b/tests/unit/test_accumulators.py
@@ -28,7 +28,7 @@ def test_info_functions_mol(LiH_sto3g_rhf):
         "pgrad": pyq.gradient_generator(mol, wf, to_opt),
         "obdm": OBDMAccumulator(mol, orb_coeff=mf.mo_coeff),
         "tbdm_updown": TBDMAccumulator(mol, np.asarray([mf.mo_coeff] * 2), (0, 1)),
-        "rotation_z_pi": SymmetryAccumulator(symm_matrix_repr=np.array([[-1, 0, 0],[0, -1, 0],[0, 0, 1]]))
+        "rotation_z_pi": SymmetryAccumulator(transformation_matrix=np.array([[-1, 0, 0],[0, -1, 0],[0, 0, 1]]))
     }
     info_functions(mol, wf, accumulators)
 


### PR DESCRIPTION
Allows us to initialize a symmetry accumulator for vmc or dmc. Tells us how the many-body wave function transforms under symmetry operations of a point group.