### PR TITLE
use dtype attribute instead of iscomplex where appropriate

### DIFF
--- a/pyqmc/addwf.py
+++ b/pyqmc/addwf.py
@@ -14,11 +14,11 @@ class AddWF:
         self.coeffs = coeffs
         self.wf_components = wf_components
         self.parameters = Parameters([wf.parameters for wf in wf_components])
-        self.iscomplex = bool(
-            sum(wf.iscomplex for wf in wf_components)
+        iscomplex = bool(
+            sum(wf.dtype==complex for wf in wf_components)
             + sum([isinstance(c, complex) * 1 for c in coeffs])
         )
-        self.dtype = complex if self.iscomplex else float
+        self.dtype = complex if iscomplex else float
 
     def recompute(self, configs):
         """

--- a/pyqmc/dmc.py
+++ b/pyqmc/dmc.py
@@ -49,7 +49,7 @@ def propose_drift_diffusion(wf, configs, tstep, e):
 
     # Acceptance -- fixed-node: reject if wf changes sign
     ratio = np.abs(wfratio) ** 2 * t_prob
-    if not wf.iscomplex:
+    if wf.dtype == float:
         ratio *= np.sign(wfratio)
     accept = ratio > np.random.rand(nconfig)
     r2 = np.sum((gauss + grad) ** 2, axis=1)

--- a/pyqmc/eval_ecp.py
+++ b/pyqmc/eval_ecp.py
@@ -8,7 +8,7 @@ def ecp(mol, configs, wf, threshold, naip=None):
     :returns: ECP value, summed over all the electrons and atoms.
     """
     nconf, nelec = configs.configs.shape[0:2]
-    ecp_tot = np.zeros(nconf, dtype=complex if wf.iscomplex else float)
+    ecp_tot = np.zeros(nconf, dtype=wf.dtype)
     if mol._ecp != {}:
         for atom in mol._atom:
             if atom[0] in mol._ecp.keys():
@@ -65,7 +65,7 @@ def ecp_ea(mol, configs, wf, e, atom, threshold, naip=None):
     TODO: update documentation
     """
     nconf = configs.configs.shape[0]
-    ecp_val = np.zeros(nconf, dtype=complex if wf.iscomplex else float)
+    ecp_val = np.zeros(nconf, dtype=wf.dtype)
 
     at_name, apos = atom
     apos = np.asarray(apos)

--- a/pyqmc/j3.py
+++ b/pyqmc/j3.py
@@ -15,7 +15,6 @@ class J3:
         randpos = np.random.random((1, 3))
         dim = mol.eval_gto("GTOval_cart", randpos).shape[-1]
         self.parameters = {"gcoeff": gpu.cp.zeros((dim, dim))}
-        self.iscomplex = False
         self.dtype = float
         self.optimize = "greedy"
 

--- a/pyqmc/j3.py
+++ b/pyqmc/j3.py
@@ -16,6 +16,7 @@ class J3:
         dim = mol.eval_gto("GTOval_cart", randpos).shape[-1]
         self.parameters = {"gcoeff": gpu.cp.zeros((dim, dim))}
         self.iscomplex = False
+        self.dtype = float
         self.optimize = "greedy"
 
     def recompute(self, configs):

--- a/pyqmc/jastrowspin.py
+++ b/pyqmc/jastrowspin.py
@@ -31,7 +31,6 @@ class JastrowSpin:
         self._mol = mol
         self.parameters["bcoeff"] = gpu.cp.zeros((len(b_basis), 3))
         self.parameters["acoeff"] = gpu.cp.zeros((self._mol.natm, len(a_basis), 2))
-        self.iscomplex = False
         self.dtype = float
 
     def recompute(self, configs):

--- a/pyqmc/jastrowspin.py
+++ b/pyqmc/jastrowspin.py
@@ -32,6 +32,7 @@ class JastrowSpin:
         self.parameters["bcoeff"] = gpu.cp.zeros((len(b_basis), 3))
         self.parameters["acoeff"] = gpu.cp.zeros((self._mol.natm, len(a_basis), 2))
         self.iscomplex = False
+        self.dtype = float
 
     def recompute(self, configs):
         r"""

--- a/pyqmc/multiplywf.py
+++ b/pyqmc/multiplywf.py
@@ -62,8 +62,8 @@ class MultiplyWF:
     def __init__(self, *wf_factors):
         self.wf_factors = [*wf_factors]
         self.parameters = Parameters([wf.parameters for wf in wf_factors])
-        self.iscomplex = bool(sum(wf.iscomplex for wf in wf_factors))
-        self.dtype = complex if self.iscomplex else float
+        iscomplex = bool(sum(wf.dtype==complex for wf in wf_factors))
+        self.dtype = complex if iscomplex else float
 
     def recompute(self, configs):
         signs = np.ones(len(configs.configs))

--- a/pyqmc/obdm.py
+++ b/pyqmc/obdm.py
@@ -84,7 +84,7 @@ class OBDMAccumulator:
                 mol, [orb_coeff, orb_coeff], kpts
             )
 
-        self.iscomplex = self.orbitals.iscomplex
+        self.dtype = self.orbitals.mo_dtype
 
         self._tstep = tstep
         self.nelec = len(self._electrons)
@@ -118,9 +118,8 @@ class OBDMAccumulator:
             self.warm_up(naux)
             self._warmed_up = True
 
-        dtype = complex if self.iscomplex else float
         results = {
-            "value": np.zeros((nconf, self.norb, self.norb), dtype=dtype),
+            "value": np.zeros((nconf, self.norb, self.norb), dtype=self.dtype),
             "norm": np.zeros((nconf, self.norb)),
         }
         naux = self._extra_config.configs.shape[0]

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -263,7 +263,7 @@ def correlated_sample(wfs, configs, parameters, pgrad):
 
     wt0 = 1.0 / np.sum(np.exp(-2 * (log_values0[:, np.newaxis] - log_values0)), axis=1)
     weight = np.mean(wt0, axis=1)
-    dtype = complex if wfs[-1].iscomplex else float
+    dtype = wfs[-1].dtype
 
     data = {
         "total": np.zeros(nparms),
@@ -545,7 +545,7 @@ def optimize_orthogonal(
 
     # One set of configurations for every wave function
     allcoords = [coords.copy() for _ in wfs[:-1]]
-    dtype = np.complex if wfs[-1].iscomplex else np.float
+    dtype = wfs[-1].dtype
 
     for step in range(max_iterations):
         # we iterate until the normalization is reasonable

--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -68,12 +68,16 @@ def choose_evaluator_from_pyscf(
 
 class MoleculeOrbitalEvaluator:
     def __init__(self, mol, mo_coeff):
-        self.iscomplex = False
         self.parameters = {
             "mo_coeff_alpha": gpu.cp.asarray(mo_coeff[0]),
             "mo_coeff_beta": gpu.cp.asarray(mo_coeff[1]),
         }
         self.parm_names = ["_alpha", "_beta"]
+        self.iscomplex = bool(
+            sum(map(gpu.cp.iscomplexobj, self.parameters.values()))
+        )
+        self.ao_dtype = True
+        self.mo_dtype = complex if self.iscomplex else float
 
         self._mol = mol
 

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -133,11 +133,11 @@ class Slater:
 
         self.parameters = JoinParameters([self.myparameters, self.orbitals.parameters])
 
-        self.iscomplex = self.orbitals.iscomplex or bool(
+        iscomplex = self.orbitals.mo_dtype==complex or bool(
             sum(map(gpu.cp.iscomplexobj, self.parameters.values()))
         )
-        self.dtype = complex if self.iscomplex else float
-        self.get_phase = get_complex_phase if self.iscomplex else gpu.cp.sign
+        self.dtype = complex if iscomplex else float
+        self.get_phase = get_complex_phase if iscomplex else gpu.cp.sign
 
     def recompute(self, configs):
         """This computes the value from scratch. Returns the logarithm of the wave function as

--- a/pyqmc/tbdm.py
+++ b/pyqmc/tbdm.py
@@ -81,7 +81,7 @@ class TBDMAccumulator:
             norb_up = np.sum([o.shape[1] for o in orb_coeff[0]])
             norb_down = np.sum([o.shape[1] for o in orb_coeff[1]])
 
-        self.dtype = complex if self.orbitals.iscomplex else float
+        self.dtype = self.orbitals.mo_dtype
         self._spin_sector = spin
         self._electrons = [
             np.arange(spin[s] * mol.nelec[0], mol.nelec[0] + spin[s] * mol.nelec[1])

--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -56,10 +56,9 @@ def test_updateinternals(wf, configs):
     nconf, ne, ndim = configs.configs.shape
     delta = 1e-2
 
-    iscomplex = 1j if wf.iscomplex else 1
-    updatevstest = np.zeros((ne, nconf)) * iscomplex
-    recomputevstest = np.zeros((ne, nconf)) * iscomplex
-    recomputevsupdate = np.zeros((ne, nconf)) * iscomplex
+    updatevstest = np.zeros((ne, nconf), dtype=wf.dtype)
+    recomputevstest = np.zeros((ne, nconf), dtype=wf.dtype)
+    recomputevsupdate = np.zeros((ne, nconf), dtype=wf.dtype)
     wfcopy = copy.copy(wf)
     val1 = wf.recompute(configs)
     for e in range(ne):
@@ -120,11 +119,10 @@ def test_wf_gradient(wf, configs, delta=1e-5):
     :rtype: dictionary
     """
     nconf, nelec = configs.configs.shape[0:2]
-    iscomplex = 1j if wf.iscomplex else 1
     wf.recompute(configs)
     maxerror = 0
-    grad = np.zeros(configs.configs.shape) * iscomplex
-    numeric = np.zeros(configs.configs.shape) * iscomplex
+    grad = np.zeros(configs.configs.shape, dtype=wf.dtype)
+    numeric = np.zeros(configs.configs.shape, dtype=wf.dtype)
     for e in range(nelec):
         grad[:, e, :] = wf.gradient(e, configs.electron(e)).T
         for d in range(0, 3):
@@ -142,7 +140,6 @@ def test_wf_gradient(wf, configs, delta=1e-5):
 
 
 def test_wf_pgradient(wf, configs, delta=1e-5):
-    dtype = complex if wf.iscomplex else float
     baseval = wf.recompute(configs)
     gradient = wf.pgradient()
     error = {}
@@ -150,7 +147,7 @@ def test_wf_pgradient(wf, configs, delta=1e-5):
         flt = wf.parameters[k].reshape(-1)
         # print(flt.shape,wf.parameters[k].shape,gradient[k].shape)
         nparms = len(flt)
-        numgrad = np.zeros((configs.configs.shape[0], nparms), dtype=dtype)
+        numgrad = np.zeros((configs.configs.shape[0], nparms), dtype=wf.dtype)
         for i, c in enumerate(flt):
             flt[i] += delta
             wf.parameters[k] = flt.reshape(wf.parameters[k].shape)
@@ -193,11 +190,10 @@ def test_wf_laplacian(wf, configs, delta=1e-5):
     :rtype: dictionary
     """
     nconf, nelec = configs.configs.shape[0:2]
-    iscomplex = 1j if wf.iscomplex else 1
     wf.recompute(configs)
     maxerror = 0
-    lap = np.zeros(configs.configs.shape[:2]) * iscomplex
-    numeric = np.zeros(configs.configs.shape[:2]) * iscomplex
+    lap = np.zeros(configs.configs.shape[:2], dtype=wf.dtype)
+    numeric = np.zeros(configs.configs.shape[:2], dtype=wf.dtype)
 
     for e in range(nelec):
         lap[:, e] = wf.laplacian(e, configs.electron(e))
@@ -221,13 +217,12 @@ def test_wf_laplacian(wf, configs, delta=1e-5):
 
 def test_wf_gradient_laplacian(wf, configs):
     nconf, nelec = configs.configs.shape[0:2]
-    iscomplex = 1j if wf.iscomplex else 1
     wf.recompute(configs)
     maxerror = 0
-    lap = np.zeros(configs.configs.shape[:2]) * iscomplex
-    grad = np.zeros(configs.configs.shape).transpose((1, 2, 0)) * iscomplex
-    andlap = np.zeros(configs.configs.shape[:2]) * iscomplex
-    andgrad = np.zeros(configs.configs.shape).transpose((1, 2, 0)) * iscomplex
+    lap = np.zeros(configs.configs.shape[:2], dtype=wf.dtype)
+    grad = np.zeros(configs.configs.shape, dtype=wf.dtype).transpose((1, 2, 0))
+    andlap = np.zeros(configs.configs.shape[:2], dtype=wf.dtype)
+    andgrad = np.zeros(configs.configs.shape, dtype=wf.dtype).transpose((1, 2, 0))
 
     tsep = 0
     ttog = 0
@@ -262,14 +257,13 @@ def compare_nested_saved_vals(saved1, saved2):
 
 def test_wf_gradient_value(wf, configs):
     nconf, nelec = configs.configs.shape[0:2]
-    iscomplex = 1j if wf.iscomplex else 1
     wf.recompute(configs)
     maxerror = 0
-    val = np.zeros(configs.configs.shape[:2]) * iscomplex
-    grad = np.zeros(configs.configs.shape).transpose((1, 2, 0)) * iscomplex
-    andval = np.zeros(configs.configs.shape[:2]) * iscomplex
-    andgrad = np.zeros(configs.configs.shape).transpose((1, 2, 0)) * iscomplex
-    saved_diff = np.zeros(configs.configs.shape[0])
+    val = np.zeros(configs.configs.shape[:2], dtype=wf.dtype)
+    grad = np.zeros(configs.configs.shape, dtype=wf.dtype).transpose((1, 2, 0))
+    andval = np.zeros(configs.configs.shape[:2], dtype=wf.dtype)
+    andgrad = np.zeros(configs.configs.shape, dtype=wf.dtype).transpose((1, 2, 0))
+    saved_diff = np.zeros(configs.configs.shape[0], dtype=wf.dtype)
 
     tsep = 0
     ttog = 0

--- a/pyqmc/three_body_jastrow.py
+++ b/pyqmc/three_body_jastrow.py
@@ -42,7 +42,6 @@ class ThreeBodyJastrow:
         self.parameters["ccoeff"] = np.zeros(
             (self._mol.natm, len(a_basis), len(a_basis), len(b_basis), 3)
         )
-        self.iscomplex = False
         self.dtype = float
 
     def recompute(self, configs):

--- a/pyqmc/three_body_jastrow.py
+++ b/pyqmc/three_body_jastrow.py
@@ -43,6 +43,7 @@ class ThreeBodyJastrow:
             (self._mol.natm, len(a_basis), len(a_basis), len(b_basis), 3)
         )
         self.iscomplex = False
+        self.dtype = float
 
     def recompute(self, configs):
         r"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from pyscf import lib, gto, scf
 import pyscf.pbc
 import numpy as np
-import pyscf.hci
+#import pyscf.hci
 
 """ 
 In this file, we set up several pyscf objects that can be reused across the 


### PR DESCRIPTION
In several places, we use statements like `dtype=complex if wf.iscomplex else float`.

These are replaced by `dtype=wf.dtype`.

Orbitals have ao_dtype as well as mo_dtype, since AOs may be real even if MO coefficients are complex.