### PR TITLE
Correlated sampling for ECPs

### DIFF
--- a/pyqmc/linemin.py
+++ b/pyqmc/linemin.py
@@ -266,7 +266,9 @@ def correlated_compute(wf, configs, params, pgrad_acc):
     data = []
     psi0 = wf.recompute(configs)[1]  # recompute gives logdet
 
+    current_state = np.random.get_state()
     for p in params:
+        np.random.set_state(current_state)
         newparms = pgrad_acc.transform.deserialize(wf, p)
         for k in newparms:
             wf.parameters[k] = newparms[k]

--- a/pyqmc/optimize_excited_states.py
+++ b/pyqmc/optimize_excited_states.py
@@ -407,7 +407,9 @@ def correlated_sampling_worker(wfs, configs, energy, transforms, parameters):
 
     energy_final = []
     overlap_final = []
+    current_state = np.random.get_state()
     for p, parameter in enumerate(parameters):
+        np.random.set_state(current_state)
         for wf, transform, wf_parm in zip(wfs, transforms, parameter):
             for k, it in transform.deserialize(wf, wf_parm).items():
                 wf.parameters[k] = it

--- a/pyqmc/optimize_ortho.py
+++ b/pyqmc/optimize_ortho.py
@@ -272,7 +272,9 @@ def correlated_sample(wfs, configs, parameters, pgrad):
         "rhoprime": np.zeros(nparms),
     }
     data["base_weight"] = weight
+    current_state = np.random.get_state()
     for p, parameter in enumerate(parameters):
+        np.random.set_state(current_state)
         wf = wfs[-1]
         for k, it in pgrad.transform.deserialize(wf, parameter).items():
             wf.parameters[k] = it

--- a/pyqmc/three_body_jastrow.py
+++ b/pyqmc/three_body_jastrow.py
@@ -155,7 +155,7 @@ class ThreeBodyJastrow:
         e_partial: partial sum of U with respect to electron e. array of shape [nelec-1,nelec,...,nconfig].
 
         .. math::
-            \text{e_partial}_{ji} = \sum_{Iklm \sigma_i \sigma_j} c_{klmI\sigma_j\sigma_i} a_k(r_{iI}) a_l(r_{jI}) b_m(r_{ij})
+            \text{e\_partial}_{ji} = \sum_{Iklm \sigma_i \sigma_j} c_{klmI\sigma_j\sigma_i} a_k(r_{iI}) a_l(r_{jI}) b_m(r_{ij})
 
         ae: new a_values for distances of electron e with ion. array of shape [nconfig,n_Ions,n_abasis]
 
@@ -219,7 +219,7 @@ class ThreeBodyJastrow:
         e_partial: partial sum of U with respect to electron e. array of shape [nelec-1,nelec,...,nconfig].
 
         .. math::
-            \text{e_partial}_{ji}  =  \sum_{Iklm \sigma_i \sigma_j} c_{klmI\sigma_j\sigma_i} a_k(r_{iI}) a_l(r_{jI}) b_m(r_{ij})
+            \text{e\_partial}_{ji}  =  \sum_{Iklm \sigma_i \sigma_j} c_{klmI\sigma_j\sigma_i} a_k(r_{iI}) a_l(r_{jI}) b_m(r_{ij})
 
         ae: new a_values for distances of electron e with ion. array of shape [nconfig,n_Ions,n_abasis]
 


### PR DESCRIPTION
Correlated sampling line_cost has much smaller fluctuations when using the same random numbers to evaluate ECPs at each parameter sample.

This PR saves the random state before looping over parameter samples, then sets the random state to the saved state each iteration.

Change implemented in linemin.py, optimize_ortho.py, optimize_excited_states.py.