### PR TITLE
Set precision for GTO evaulation as kwarg for a number of classes, determined on a default value, modified some tests

### DIFF
--- a/pyqmc/geminaljastrow.py
+++ b/pyqmc/geminaljastrow.py
@@ -32,7 +32,7 @@ class GeminalJastrow:
     The independent parameters are :math:`g_{mn} = \tilde g_{mn} + \tilde g_{nm}, \; m \le n`.
     """
 
-    def __init__(self, mol, orbitals=None):
+    def __init__(self, mol, orbitals=None, eval_gto_precision=None):
         if orbitals is None:
             if hasattr(mol, "lattice_vectors"):
                 if not hasattr(mol, "original_cell"):
@@ -41,7 +41,7 @@ class GeminalJastrow:
                     mol = make_pbc_supercell_for_gamma_aos(mol)
                 kpts = [[0, 0, 0]]
                 self.orbitals = pyqmc.orbitals.PBCOrbitalEvaluatorKpoints(
-                    mol, kpts=kpts
+                    mol, kpts=kpts, eval_gto_precision=eval_gto_precision
                 )
             else:
                 self.orbitals = pyqmc.orbitals.MoleculeOrbitalEvaluator(mol, [0, 0])

--- a/pyqmc/obdm.py
+++ b/pyqmc/obdm.py
@@ -44,6 +44,8 @@ class OBDMAccumulator:
         extra coordinate.
 
       spin: 0 or 1 for up or down. Defaults to all electrons.
+
+      eval_gto_precision (float): desired value of orbital at rcut, used for determining rcut for periodic system. Default value = 0.01
     """
 
     def __init__(
@@ -57,6 +59,7 @@ class OBDMAccumulator:
         spin=None,
         electrons=None,
         kpts=None,
+        eval_gto_precision=None,
     ):
         if spin is not None:
             if spin == 0:
@@ -80,7 +83,7 @@ class OBDMAccumulator:
             if not hasattr(mol, "original_cell"):
                 mol = supercell.get_supercell(mol, np.eye(3))
             self.orbitals = pyqmc.orbitals.PBCOrbitalEvaluatorKpoints(
-                mol, [orb_coeff, orb_coeff], kpts
+                mol, [orb_coeff, orb_coeff], kpts, eval_gto_precision=eval_gto_precision
             )
 
         self.dtype = self.orbitals.mo_dtype

--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -81,7 +81,7 @@ class PBCOrbitalEvaluatorKpoints:
         :parameter cell: PyQMC supercell object (from get_supercell)
         :parameter mo_coeff: (2, nk, nao, nelec) array. MO coefficients for all kpts of primitive cell. If None, this object can't evaluate mos(), but can still evaluate aos().
         :parameter kpts: list of kpts to evaluate AOs
-        :eval_gto_precision: desired value of orbital at rcut, used for determining rcut for periodic. If None, rcut = 1
+        :eval_gto_precision: desired value of orbital at rcut, used for determining rcut for periodic system. Default value = 0.01
         """
         self._cell = cell.original_cell
         self.S = cell.S

--- a/pyqmc/pyscftools.py
+++ b/pyqmc/pyscftools.py
@@ -94,7 +94,7 @@ def orbital_evaluator_from_pyscf(
     twist: the twist of the calculation (units?)
     determinants: A list of determinants suitable to pass into create_packed_objects
     tol: smallest determinant weight to include in the wave function.
-    eval_gto_precision: desired value of orbital at rcut, used for determining rcut for periodic. If None, rcut = 1
+    eval_gto_precision: desired value of orbital at rcut, used for determining rcut for periodic system. Default value = 0.01
     
     You cannot pass both mc/tol and determinants.
 

--- a/pyqmc/pyscftools.py
+++ b/pyqmc/pyscftools.py
@@ -85,7 +85,7 @@ def recover_pyscf(chkfile, ci_checkfile=None, cancel_outputs=True):
 
 
 def orbital_evaluator_from_pyscf(
-    mol, mf, mc=None, twist=0, determinants=None, tol=None
+    mol, mf, mc=None, twist=0, determinants=None, tol=None, eval_gto_precision=None
 ):
     """
     mol: A Mole object
@@ -94,7 +94,8 @@ def orbital_evaluator_from_pyscf(
     twist: the twist of the calculation (units?)
     determinants: A list of determinants suitable to pass into create_packed_objects
     tol: smallest determinant weight to include in the wave function.
-
+    eval_gto_precision: desired value of orbital at rcut, used for determining rcut for periodic. If None, rcut = 1
+    
     You cannot pass both mc/tol and determinants.
 
     :returns:
@@ -129,7 +130,7 @@ def orbital_evaluator_from_pyscf(
         max_orb = np.amax(max_orb, axis=0)
         mo_coeff = [[_mo_coeff[s][k][:, 0 : max_orb[s][k]] for k in kinds] for s in [0, 1]]
 
-        evaluator = orbitals.PBCOrbitalEvaluatorKpoints(mol, mo_coeff, kpts)
+        evaluator = orbitals.PBCOrbitalEvaluatorKpoints(mol, mo_coeff, kpts, eval_gto_precision)
         determinants = determinant_tools.flatten_determinants(determinants, max_orb, kinds)
     else:
         max_orb = [[f_max_orb(s) for s in det] for wt, det in determinants]

--- a/pyqmc/slater.py
+++ b/pyqmc/slater.py
@@ -138,7 +138,7 @@ class Slater:
 
     """
 
-    def __init__(self, mol, mf, mc=None, tol=None, twist=0, determinants=None):
+    def __init__(self, mol, mf, mc=None, tol=None, twist=0, determinants=None, eval_gto_precision=None):
         """
         determinants should be a list of tuples, for example
         [ (1.0, [0,1],[0,1]),
@@ -158,6 +158,7 @@ class Slater:
         else:
             self._nelec = mol.nelec
 
+        self.eval_gto_precision = eval_gto_precision
         self.myparameters = {}
         (
             self.myparameters["det_coeff"],
@@ -165,7 +166,7 @@ class Slater:
             self._det_map,
             self.orbitals,
         ) = pyqmc.pyscftools.orbital_evaluator_from_pyscf(
-            mol, mf, mc, twist=twist, determinants=determinants, tol=self.tol
+            mol, mf, mc, twist=twist, determinants=determinants, tol=self.tol, eval_gto_precision=self.eval_gto_precision
         )
 
         self.parameters = JoinParameters([self.myparameters, self.orbitals.parameters])

--- a/pyqmc/tbdm.py
+++ b/pyqmc/tbdm.py
@@ -42,6 +42,8 @@ class TBDMAccumulator:
          for up-up, up-down, down-up or down-down.
 
       ijkl (array): contains M tbdm matrix elements to calculate with dim (M,4).
+
+      eval_gto_precision (float): desired value of orbital at rcut, used for determining rcut for periodic system. Default value = 0.01
     """
 
     def __init__(
@@ -55,6 +57,7 @@ class TBDMAccumulator:
         naux=None,
         ijkl=None,
         kpts=None,
+        eval_gto_precision=None,
     ):
         self._mol = mol
         self._tstep = tstep
@@ -75,7 +78,7 @@ class TBDMAccumulator:
             if not hasattr(mol, "original_cell"):
                 mol = supercell.get_supercell(mol, np.eye(3))
             self.orbitals = pyqmc.orbitals.PBCOrbitalEvaluatorKpoints(
-                mol, orb_coeff, kpts
+                mol, orb_coeff, kpts, eval_gto_precision=eval_gto_precision
             )
             norb_up = np.sum([o.shape[1] for o in orb_coeff[0]])
             norb_down = np.sum([o.shape[1] for o in orb_coeff[1]])

--- a/tests/integration/test_twist.py
+++ b/tests/integration/test_twist.py
@@ -19,7 +19,7 @@ def runtest(mol, mf, kind=0):
     supercell = pyq.get_supercell(mol, np.identity(3))
     twists = pyq.create_supercell_twists(supercell, mf, 12)
     kpt = twists["twists"][kind]
-    wft = Slater(mol, mf, twist=kind, eval_gto_precision=1e-6)
+    wft = Slater(mol, mf, twist=kind, eval_gto_precision=1e-8)
 
     #####################################
     ## compare values across boundary

--- a/tests/integration/test_twist.py
+++ b/tests/integration/test_twist.py
@@ -19,7 +19,7 @@ def runtest(mol, mf, kind=0):
     supercell = pyq.get_supercell(mol, np.identity(3))
     twists = pyq.create_supercell_twists(supercell, mf, 12)
     kpt = twists["twists"][kind]
-    wft = Slater(mol, mf, twist=kind)
+    wft = Slater(mol, mf, twist=kind, eval_gto_precision=1e-6)
 
     #####################################
     ## compare values across boundary

--- a/tests/unit/test_wf_derivatives.py
+++ b/tests/unit/test_wf_derivatives.py
@@ -82,13 +82,13 @@ def test_pbc_wfs(H_pbc_sto3g_krks, epsilon=1e-5, nconf=10):
     supercell = pyq.get_supercell(mol, S=(np.ones((3, 3)) - 2 * np.eye(3)))
     epos = pyq.initial_guess(supercell, nconf)
     for wf in [
-        MultiplyWF(Slater(supercell, mf), generate_jastrow(supercell)[0]),
+        MultiplyWF(Slater(supercell, mf, eval_gto_precision=1e-6), generate_jastrow(supercell)[0]),
         MultiplyWF(
-            Slater(supercell, mf),
+            Slater(supercell, mf, eval_gto_precision=1e-6),
             generate_jastrow(supercell)[0],
-            GeminalJastrow(supercell),
+            GeminalJastrow(supercell, eval_gto_precision=1e-6),
         ),
-        Slater(supercell, mf),
+        Slater(supercell, mf, eval_gto_precision=1e-6),
     ]:
         for k in wf.parameters:
             if "mo_coeff" not in k and k != "det_coeff":
@@ -108,8 +108,8 @@ def test_pbc_wfs_triplet(h_noncubic_sto3g_triplet, epsilon=1e-5, nconf=10):
     supercell = pyq.get_supercell(mol, S=np.identity(3, dtype=int))
     epos = pyq.initial_guess(supercell, nconf)
     for wf in [
-        MultiplyWF(Slater(supercell, mf), generate_jastrow(supercell)[0]),
-        Slater(supercell, mf),
+        MultiplyWF(Slater(supercell, mf, eval_gto_precision=1e-6), generate_jastrow(supercell)[0]),
+        Slater(supercell, mf, eval_gto_precision=1e-6),
     ]:
         for k in wf.parameters:
             if "mo_coeff" not in k and k != "det_coeff":
@@ -197,7 +197,7 @@ def test_manual_pbcs_correct(H_pbc_sto3g_kuks, epsilon=1e-5, nconf=10):
         determinants[1][1][s][ki].append(i)
 
     print(determinants[0])
-    wf = Slater(mol, mf, determinants=determinants)
+    wf = Slater(mol, mf, determinants=determinants, eval_gto_precision=1e-6)
     configs = pyq.initial_guess(mol, 10)
     run_tests(wf, configs, epsilon)
 


### PR DESCRIPTION
The precision for GTO evaluation can be now specified as a `slater_kws` (`eval_gto_precision`). It is used for determining the rcut for a periodic system. The default value of precision is 0.01.