### PR TITLE
set optimize='greedy'

### DIFF
--- a/pyqmc/ewald.py
+++ b/pyqmc/ewald.py
@@ -285,7 +285,7 @@ class Ewald:
 
     def reciprocal_space_electron(self, configs):
         # Reciprocal space electron-electron part
-        e_GdotR = gpu.cp.einsum("hik,jk->hij", gpu.cp.asarray(configs), self.gpoints)
+        e_GdotR = gpu.cp.einsum("hik,jk->hij", gpu.cp.asarray(configs), self.gpoints, optimize="greedy")
         sum_e_sin = gpu.cp.sin(e_GdotR).sum(axis=1)
         sum_e_cos = gpu.cp.cos(e_GdotR).sum(axis=1)
         ee_recip = gpu.cp.dot(sum_e_sin**2 + sum_e_cos**2, self.gweight)

--- a/pyqmc/orbitals.py
+++ b/pyqmc/orbitals.py
@@ -168,7 +168,7 @@ class PBCOrbitalEvaluatorKpoints:
         nelec = self.parameters[self.parm_names[spin]].shape[1]
         out = gpu.cp.zeros([nelec, *ao[0].shape[:-1]], dtype=self.mo_dtype)
         for i, ak, mok in zip(range(len(ao)), ao, p[:-1]):
-            gpu.cp.einsum("...a,an->n...", ak, mok, out=out[ps[i] : ps[i + 1]])
+            gpu.cp.einsum("...a,an->n...", ak, mok, out=out[ps[i] : ps[i + 1]], optimize="greedy")
         return out.transpose([*np.arange(1, len(out.shape)), 0])
 
     def pgradient(self, ao, spin):


### PR DESCRIPTION
Add `optimize="greedy"` to einsum calls in orbitals.mos and ewald.reciprocal_space_electron.
This seems to speed up the calls noticeably, the mos() having bigger impact.