### PR TITLE
Fix a key error in compute_tmoves() in eval_ecp.py

### DIFF
--- a/pyqmc/eval_ecp.py
+++ b/pyqmc/eval_ecp.py
@@ -65,7 +65,7 @@ def compute_tmoves(mol, configs, wf, e, threshold, tau, naip=None):
                 "ik, ijk -> ij", np.exp(-tau * d["v_l"]) - 1, d["P_l"]
             )
             ratio[d["mask"]] = d["ratio"]
-        else:
+        else: # if d["mask"] is all False, return empty arrays for weight, ratio and d["epos"].configs
             weight = np.zeros((nconfig, 0))
             ratio = np.ones((nconfig, 0))
         summed_data.append({"weight": weight, "ratio": ratio, "epos": d["epos"]})

--- a/pyqmc/eval_ecp.py
+++ b/pyqmc/eval_ecp.py
@@ -94,11 +94,12 @@ def ecp_ea(mol, configs, wf, e, atom, threshold, naip=None):
     l_list, v_l = get_v_l(mol, at_name, r_ea)
     mask, prob = ecp_mask(v_l, threshold)
     if not np.any(mask):
-        epos = np.zeros((nconf, 0, 3))
+        epos = configs.make_irreducible(e, np.zeros((nconf, 0, 3)))
         return {
             "total": ecp_val,
             "epos": epos,
-            "mask": mask}
+            "mask": mask
+        }
     masked_v_l = v_l[mask]
     masked_v_l[:, :-1] /= prob[mask, np.newaxis]
 

--- a/pyqmc/eval_ecp.py
+++ b/pyqmc/eval_ecp.py
@@ -60,10 +60,11 @@ def compute_tmoves(mol, configs, wf, e, threshold, tau, naip=None):
         npts = d["ratio"].shape[1]
         weight = np.zeros((nconfig, npts))
         ratio = np.ones((nconfig, npts), dtype=d["ratio"].dtype)
-        weight[d["mask"]] = np.einsum(
-            "ik, ijk -> ij", np.exp(-tau * d["v_l"]) - 1, d["P_l"]
-        )
-        ratio[d["mask"]] = d["ratio"]
+        if np.any(d["mask"]):
+            weight[d["mask"]] = np.einsum(
+                "ik, ijk -> ij", np.exp(-tau * d["v_l"]) - 1, d["P_l"]
+            )
+            ratio[d["mask"]] = d["ratio"]
         summed_data.append({"weight": weight, "ratio": ratio, "epos": d["epos"]})
 
     ratio = np.concatenate([d["ratio"] for d in summed_data], axis=1)
@@ -90,7 +91,16 @@ def ecp_ea(mol, configs, wf, e, atom, threshold, naip=None):
     l_list, v_l = get_v_l(mol, at_name, r_ea)
     mask, prob = ecp_mask(v_l, threshold)
     if not np.any(mask):
-        return {"total": ecp_val}
+        naip = 6 if len(l_list) <= 2 else 12
+        epos_rot = np.repeat(configs.configs[:, e, :][:, np.newaxis, :], naip, axis=1)
+        epos = configs.make_irreducible(e, epos_rot, mask)
+        return {
+            "total": ecp_val,
+            # "v_l": np.zeros((nconf, len(l_list))),
+            # "P_l": np.zeros((nconf, naip, len(l_list))),
+            "ratio": np.zeros((nconf, naip)),
+            "epos": epos,
+            "mask": mask}
     masked_v_l = v_l[mask]
     masked_v_l[:, :-1] /= prob[mask, np.newaxis]
 


### PR DESCRIPTION
Fix the following key error
```Traceback (most recent call last):
  File "/projects/wagner/cychow2/.conda/envs/cco-new/lib/python3.11/concurrent/futures/process.py", line 256, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/projects/wagner/cychow2/.conda/envs/cco-new/lib/python3.11/site-packages/pyqmc/dmc.py", line 171, in dmc_propagate
    newepos, mask, probability, ecp_totweight = propose_tmoves(
                                                ^^^^^^^^^^^^^^^
  File "/projects/wagner/cychow2/.conda/envs/cco-new/lib/python3.11/site-packages/pyqmc/dmc.py", line 83, in propose_tmoves
    moves = energy_accumulator.nonlocal_tmoves(configs, wf, e, tstep)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/projects/wagner/cychow2/.conda/envs/cco-new/lib/python3.11/site-packages/pyqmc/accumulators.py", line 61, in nonlocal_tmoves
    return eval_ecp.compute_tmoves(self.mol, configs, wf, e, self.threshold, tau)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/projects/wagner/cychow2/.conda/envs/cco-new/lib/python3.11/site-packages/pyqmc/eval_ecp.py", line 60, in compute_tmoves
    npts = d["ratio"].shape[1]
           ~^^^^^^^^^
KeyError: 'ratio'
```
that results from a DMC run. This occurs when the ecp mask of an atom is all `False`.