### PR TITLE
add new test for testvalue with aux coordinates

### DIFF
--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -56,6 +56,30 @@ def test_testvalue_many(wf, configs, tol=1e-6):
     assert np.max(np.abs(terr)) < tol
 
 
+def test_testvalue_aux(wf, configs, aux, tol=1e-6):
+    """
+    :parameter wf: a wave function object to be tested
+    :parameter configs: aux positions
+    :type configs: (nconf, naux, 3) array
+    :returns: max abs errors
+    :rtype: dictionary
+
+    """
+    nconf, naux, ndim = aux.configs.shape
+    val1 = wf.recompute(configs)
+    wfcopy = copy.copy(wf)
+
+    delta = 1e-2
+    tval = np.zeros((nconf, naux))
+    e = 0
+    for a in range(naux):
+        tval[:, a], _ = wf.testvalue(e, aux.select_electrons(a))
+
+    tmany, _ = wfcopy.testvalue(e, aux)
+    terr = tmany - tval
+    assert np.max(np.abs(terr)) < tol
+
+
 def test_updateinternals(wf, configs):
     """
     :parameter wf: a wave function object to be tested

--- a/pyqmc/three_body_jastrow.py
+++ b/pyqmc/three_body_jastrow.py
@@ -188,7 +188,7 @@ class ThreeBodyJastrow:
             di_e = configs.dist.dist_i(self._mol.atom_coords(), epos)
         else:
             de = configs.dist.pairwise(configs.configs[:, not_e], epos)
-            di_e = configs.dist.pairwise(self._mol.atom_coords(), epos)
+            di_e = configs.dist.pairwise(self._mol.atom_coords()[np.newaxis], epos)
             de = np.moveaxis(de, 2, 0)
             di_e = np.moveaxis(di_e, 2, 0)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,13 @@ def LiH_sto3g_rhf():
 
 
 @pytest.fixture(scope="module")
+def LiH_ccecp_rhf():
+    mol = gto.M(atom="Li 0. 0. 0.; H 0. 0. 1.5", basis="ccecp-ccpvdz", ecp="ccecp", unit="bohr")
+    mf = scf.RHF(mol).run()
+    return mol, mf
+
+
+@pytest.fixture(scope="module")
 def LiH_sto3g_uhf():
     mol = gto.M(atom="Li 0. 0. 0.; H 0. 0. 1.5", basis="sto-3g", unit="bohr")
     mf = scf.UHF(mol).run()

--- a/tests/unit/test_aux_testvalue.py
+++ b/tests/unit/test_aux_testvalue.py
@@ -1,0 +1,70 @@
+# MIT License
+# 
+# Copyright (c) 2019-2024 The PyQMC Developers
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+import os
+
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
+os.environ["OMP_NUM_THREADS"] = "1"
+import numpy as np
+from pyqmc.api import (
+    generate_wf,
+    generate_jastrow,
+    initial_guess,
+)
+from pyqmc.gpu import cp, asnumpy
+import pyqmc.testwf as testwf
+import pytest
+from pyqmc.slater import Slater
+from pyqmc.multiplywf import MultiplyWF
+from pyqmc.addwf import AddWF
+from pyqmc.geminaljastrow import GeminalJastrow
+from pyqmc.wftools import generate_jastrow,  default_jastrow_basis
+from pyqmc.three_body_jastrow import ThreeBodyJastrow
+
+
+def test_testvalue_aux(LiH_ccecp_rhf, epsilon=1e-5, nconf=10):
+    """
+    Ensure that the wave function objects are consistent in several situations.
+    """
+
+    mol, mf = LiH_ccecp_rhf
+    a_basis, b_basis = default_jastrow_basis(mol)
+    for wf in [
+        generate_jastrow(mol)[0],
+        GeminalJastrow(mol),
+        ThreeBodyJastrow(mol, a_basis, b_basis),
+        MultiplyWF(
+            Slater(mol, mf),
+            generate_jastrow(mol)[0],
+            ThreeBodyJastrow(mol, a_basis, b_basis),
+        ),
+        Slater(mol, mf),
+    ]:
+        for k in wf.parameters:
+            if k != "mo_coeff":
+                wf.parameters[k] = cp.asarray(np.random.rand(*wf.parameters[k].shape))
+
+        naux = 6
+        nelec = sum(mol.nelec)
+        configs =  initial_guess(mol, nconf)
+        aux =  initial_guess(mol, naux * (int(nconf / nelec) + 1))
+        aux.reshape((-1, naux, 3))
+        aux.resample(range(nconf))
+        print(configs.configs.shape)
+        print(aux.configs.shape)
+        print(type(wf))
+        testwf.test_testvalue_aux(wf, configs, aux)
+
+


### PR DESCRIPTION
Addresses issue #432 , three-body jastrow testvalue did not work for ECPs, now fixed.

Additionally, added a test that catches that error.