### PR TITLE
fix pgradient test error check

### DIFF
--- a/pyqmc/testwf.py
+++ b/pyqmc/testwf.py
@@ -203,7 +203,7 @@ def test_wf_pgradient(wf, configs, delta=1e-5):
 
     if len(error) == 0:
         return (0, 0)
-    return error[max(error)]  # Return maximum coefficient error
+    return max(error.values())  # Return maximum coefficient error
 
 
 def test_wf_laplacian(wf, configs, delta=1e-5):


### PR DESCRIPTION
`error[max(error)]` was intended to return the maximum error in the dictionary `error`, however, `max(error)` returns the maximum of the keys themselves, not the key of the maximum value. So this is changed to `max(error.values())`.