### PR TITLE
Reverse order of convert_to_khf and to_uhf()

### DIFF
--- a/pyqmc/pyscftools.py
+++ b/pyqmc/pyscftools.py
@@ -121,13 +121,14 @@ def orbital_evaluator_from_pyscf(
     periodic = hasattr(mol, "a")
     f_max_orb = lambda a: int(np.max(a, initial=0)) + 1 if len(a) > 0 else 0
 
+    if periodic:
+        mf = pyscf.pbc.scf.addons.convert_to_khf(mf)
+
     try:
         mf = mf.to_uhf()
     except TypeError:
         mf = mf.to_uhf(mf)
 
-    if periodic:
-        mf = pyscf.pbc.scf.addons.convert_to_khf(mf)
     if determinants is None:
         determinants = determinants_from_pyscf(mol, mf, mc=mc, tol=tol)
 


### PR DESCRIPTION
Pyscf seems to have a bug if you use to_uhf()  and then convert_to_khf. It does work the other way around.