### PR TITLE
Changed in-place multiplication of wf parameters to out-of-place

### DIFF
--- a/pyqmc/method/ensemble_optimization_wfbywf.py
+++ b/pyqmc/method/ensemble_optimization_wfbywf.py
@@ -216,9 +216,9 @@ def renormalize(wfs, norms, pivot=0, N=1):
             continue
         renorm = np.sqrt(norms[pivot] / norms[i] * N)
         if "wf1det_coeff" in wfs[-1].parameters.keys():
-            wf.parameters["wf1det_coeff"] *= renorm
+            wf.parameters["wf1det_coeff"] = wf.parameters["wf1det_coeff"] * renorm
         elif "det_coeff" in wfs[-1].parameters.keys():
-            wf.parameters["det_coeff"] *= renorm
+            wf.parameters["det_coeff"] = wf.parameters["det_coeff"] * renorm
         else:
             raise NotImplementedError("need wf1det_coeff or det_coeff in parameters")
 


### PR DESCRIPTION
Ensemble optimization using JAX wfs causes 
a `ValueError: output array is read-only` from the line
```Python
wf.parameters["wf1det_coeff"] *= renorm
```
in pyqmc/method/ensemble_optimization_wfbywf.py, because `*=` invokes `__imul__` before `__setitem__` , and we didn't overwrite `__imul__` in our `_parameterMap` class.
Changing the in-place multiplication to an out-of-place one should fix this bug.