### PR TITLE
Update documentation for test_transform_consistent_with_wf

### DIFF
--- a/tests/unit/test_evaluate_gradients_threaded.py
+++ b/tests/unit/test_evaluate_gradients_threaded.py
@@ -5,6 +5,7 @@ from concurrent.futures import ProcessPoolExecutor
 
 
 def test_transform_consistent_with_wf(H2_casci):
+    """Test that evaluate_gradient_threaded works when given states with different numbers of determinants"""
     from pyqmc.method.ensemble_optimization_wfbywf import StochasticReconfigurationWfbyWf
     from pyqmc.method.ensemble_optimization_threaded import evaluate_gradients_threaded
     mol, mf, mc = H2_casci
@@ -14,7 +15,7 @@ def test_transform_consistent_with_wf(H2_casci):
 
     energy = pyq.EnergyAccumulator(mol)
     sr_accumulator = []
-    tol = 1e-20
+    tol = 1e-20 # With tol = 1e-20 state 0 has 4 determinants whereas state 1 will have 3
     wfs = []
     for i in range(2):
     
@@ -36,6 +37,8 @@ def test_transform_consistent_with_wf(H2_casci):
     [[copy.deepcopy(configs) for _ in range(2)] for _ in range(len(sr_accumulator[wfi]))]
     for wfi in range(2)
 ]   
+    for i,wf in enumerate(wfs):
+        print(f"For wf{i} {len(wf.parameters['det_coeff']) = }")
     with ProcessPoolExecutor() as executor:
         _, data_unweighted, configs = pyqmc.method.sample_many.sample_overlap(
                 wfs,

--- a/tests/unit/test_evaluate_gradients_threaded.py
+++ b/tests/unit/test_evaluate_gradients_threaded.py
@@ -18,7 +18,6 @@ def test_transform_consistent_with_wf(H2_casci):
     tol = 1e-20 # With tol = 1e-20 state 0 has 4 determinants whereas state 1 will have 3
     wfs = []
     for i in range(2):
-    
         wf, to_opt = pyq.generate_slater(mol, mf, mc=mcs[i], optimize_determinants=True, tol = tol)
         wfs.append(wf)
         sr_accumulator.append(
@@ -31,8 +30,7 @@ def test_transform_consistent_with_wf(H2_casci):
                 )
             ]
         )
-           
-    configs = pyq.initial_guess(mol, 100)
+    configs = pyq.initial_guess(mol, 1)
     configs_ensemble = [
     [[copy.deepcopy(configs) for _ in range(2)] for _ in range(len(sr_accumulator[wfi]))]
     for wfi in range(2)


### PR DESCRIPTION
Added docstring to test, a comment explaining what the value of tol was doing and a print statement to display number of determinants in each state. Also reduced number of configs to 1 so the test will run faster